### PR TITLE
Remove unused properties in NI.Analysis.targets

### DIFF
--- a/configuration/NI.Analysis.targets
+++ b/configuration/NI.Analysis.targets
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <!-- TODO: This location of 'content' needs to get updated once we build our package if we decide to put the files elsewhere, outside of a 'content' directory -->
     <NI_CodeAnalysisRuleSetDirectory>$(PkgNI_DotNet_Analyzers)\content</NI_CodeAnalysisRuleSetDirectory>
-    <NI_NuGetPackagesDirectory>$(NuGetPackageRoot)</NI_NuGetPackagesDirectory>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -15,7 +14,6 @@
     <NI_IsTestUtilitiesProject Condition="'$(NI_IsTestUtilitiesProject)' != 'True'">$(MSBuildProjectName.StartsWith("!TestUtilities."))</NI_IsTestUtilitiesProject>
     <!-- The following is needed for misnamed TestUtilities that contain xaml because the generated project for the second compile appends random characters to the end of the project name -->
     <NI_IsTestUtilitiesProject Condition="'$(NI_IsTestUtilitiesProject)' != 'True' and '$(NI_IsTestProject)' != 'True'">$(MSBuildProjectName.Contains(".TestUtilities"))</NI_IsTestUtilitiesProject>
-    <NI_ProjectNameContainsTests>$(MSBuildProjectName.Contains("Tests"))</NI_ProjectNameContainsTests>
 
     <CodeAnalysisRuleSet>$(NI_CodeAnalysisRuleSetDirectory)\NI.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSet Condition="'$(NI_IsTestProjectCondition)' == 'True'">$(NI_CodeAnalysisRuleSetDirectory)\NI.Tests.ruleset</CodeAnalysisRuleSet>
@@ -48,18 +46,18 @@
     <RoslynAnalyzer Include="Text" />
 
     <!-- Microsoft's CA analyzers -->
-    <Analyzer Include="@(RoslynAnalyzer->'$(NI_NuGetPackagesDirectory)\%(Identity).analyzers\2.6.3\analyzers\dotnet\cs\%(Identity).Analyzers.dll')"/>
-    <Analyzer Include="@(RoslynAnalyzer->'$(NI_NuGetPackagesDirectory)\%(Identity).analyzers\2.6.3\analyzers\dotnet\cs\%(Identity).CSharp.Analyzers.dll')"/>
+    <Analyzer Include="@(RoslynAnalyzer->'$(NuGetPackageRoot)\%(Identity).analyzers\2.6.3\analyzers\dotnet\cs\%(Identity).Analyzers.dll')"/>
+    <Analyzer Include="@(RoslynAnalyzer->'$(NuGetPackageRoot)\%(Identity).analyzers\2.6.3\analyzers\dotnet\cs\%(Identity).CSharp.Analyzers.dll')"/>
     <Analyzer Include="$(PkgMicrosoft_VisualStudio_Threading_Analyzers)\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll"/>
     <Analyzer Include="$(PkgMicrosoft_CodeQuality_Analyzers)\analyzers\dotnet\cs\Humanizer.dll" />
 
     <!-- NI's CA analyzers -->
-    <Analyzer Include="$(NI_NuGetPackagesDirectory)\ni.codeanalysis.analyzers\1.0.2\lib\netstandard1.3\NI.CodeAnalysis.Analyzers.dll"/>
-    <Analyzer Include="$(NI_NuGetPackagesDirectory)\ni.codeanalysis.analyzers\1.0.2\lib\netstandard1.3\Utilities.dll"/>
-    <Analyzer Include="$(NI_NuGetPackagesDirectory)\ni.codequality.analyzers\1.0.2\lib\netstandard1.3\NI.CodeQuality.Analyzers.dll"/>
-    <Analyzer Include="$(NI_NuGetPackagesDirectory)\ni.codequality.analyzers\1.0.2\lib\netstandard1.3\Utilities.dll"/>
-    <Analyzer Include="$(NI_NuGetPackagesDirectory)\nationalinstruments.tools.analyzers.naming\1.0.2\lib\netstandard1.3\NationalInstruments.Tools.Analyzers.Naming.dll"/>
-    <Analyzer Include="$(NI_NuGetPackagesDirectory)\nationalinstruments.tools.analyzers.naming\1.0.2\lib\netstandard1.3\NationalInstruments.Tools.Analyzers.Utilities.dll"/>
+    <Analyzer Include="$(NuGetPackageRoot)\ni.codeanalysis.analyzers\1.0.2\lib\netstandard1.3\NI.CodeAnalysis.Analyzers.dll"/>
+    <Analyzer Include="$(NuGetPackageRoot)\ni.codeanalysis.analyzers\1.0.2\lib\netstandard1.3\Utilities.dll"/>
+    <Analyzer Include="$(NuGetPackageRoot)\ni.codequality.analyzers\1.0.2\lib\netstandard1.3\NI.CodeQuality.Analyzers.dll"/>
+    <Analyzer Include="$(NuGetPackageRoot)\ni.codequality.analyzers\1.0.2\lib\netstandard1.3\Utilities.dll"/>
+    <Analyzer Include="$(NuGetPackageRoot)\nationalinstruments.tools.analyzers.naming\1.0.2\lib\netstandard1.3\NationalInstruments.Tools.Analyzers.Naming.dll"/>
+    <Analyzer Include="$(NuGetPackageRoot)\nationalinstruments.tools.analyzers.naming\1.0.2\lib\netstandard1.3\NationalInstruments.Tools.Analyzers.Utilities.dll"/>
 
     <!-- Configuration files for our analyzers -->
     <!-- By adding the Link attribute, these files will not be shown in the Solution Explorer for .NET Core projects. -->


### PR DESCRIPTION
# Justification
I removed one property which wasn't used at all, NI_ProjectNameContainsTests.
I removed a property, NI_NuGetPackagesDirectory, since it's basically the same thing as NuGetPackageRoot.

# Implementation
Removed those properties and replaced NI_NuGetPackagesDirectory with NuGetPackageRoot.

# Testing
Can't test the package yet, so I'm adding a few others to this PR.