### PR TITLE
Cleanup rulesets by removing duplicate, unused or incorrect configurations

### DIFF
--- a/rulesets/NI.TestUtilities.ruleset
+++ b/rulesets/NI.TestUtilities.ruleset
@@ -9,13 +9,10 @@
     <Rule Id="CA1008" Action="None" />
     <Rule Id="CA1017" Action="None" />
     <Rule Id="CA1018" Action="None" />
-    <Rule Id="CA1019" Action="Warning" />
     <Rule Id="CA1024" Action="None" />
-    <Rule Id="CA1026" Action="None" />
     <Rule Id="CA1027" Action="None" />
     <Rule Id="CA1030" Action="None" />
     <Rule Id="CA1032" Action="None" />
-    <Rule Id="CA1034" Action="Warning" />
     <Rule Id="CA1040" Action="None" />
     <Rule Id="CA1051" Action="None" />
     <Rule Id="CA1054" Action="None" />
@@ -24,11 +21,8 @@
     <Rule Id="CA1304" Action="None" />
     <Rule Id="CA1305" Action="None" />
     <Rule Id="CA1308" Action="None" />
-    <Rule Id="CA1405" Action="None" />
-    <Rule Id="CA1702" Action="None" />
     <Rule Id="CA1704" Action="None" />
     <Rule Id="CA1707" Action="None" />
-    <Rule Id="CA1709" Action="None" />
     <Rule Id="CA1710" Action="None" />
     <Rule Id="CA1711" Action="None" />
     <Rule Id="CA1712" Action="None" />
@@ -50,11 +44,8 @@
     <Rule Id="CA1824" Action="None" />
     <Rule Id="CA2001" Action="None" />
     <Rule Id="CA2002" Action="None" />
-    <Rule Id="CA2004" Action="None" />
     <Rule Id="CA2008" Action="None" />
-    <Rule Id="CA2105" Action="None" />
     <Rule Id="CA2201" Action="None" />
-    <Rule Id="CA2202" Action="None" />
     <Rule Id="CA2208" Action="None" />
     <Rule Id="CA2211" Action="None" />
     <Rule Id="CA2213" Action="None" />
@@ -63,58 +54,9 @@
     <Rule Id="CA2235" Action="None" />
     <Rule Id="CA2242" Action="None" />
   </Rules>
-  <Rules AnalyzerId="Desktop.Analyzers" RuleNamespace="Desktop.Analyzers">
-    <Rule Id="CA2235" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.ApiDesignGuidelines.Analyzers" RuleNamespace="Microsoft.ApiDesignGuidelines.Analyzers">
-    <Rule Id="CA1008" Action="None" />
-    <Rule Id="CA1017" Action="None" />
-    <Rule Id="CA1018" Action="None" />
-    <Rule Id="CA1024" Action="None" />
-    <Rule Id="CA1027" Action="None" />
-    <Rule Id="CA1030" Action="None" />
-    <Rule Id="CA1034" Action="Warning" />
-    <Rule Id="CA1051" Action="None" />
-    <Rule Id="CA1054" Action="None" />
-    <Rule Id="CA1064" Action="None" />
-    <Rule Id="CA1065" Action="None" />
-    <Rule Id="CA1707" Action="None" />
-    <Rule Id="CA1710" Action="None" />
-    <Rule Id="CA1711" Action="None" />
-    <Rule Id="CA1712" Action="None" />
-    <Rule Id="CA1714" Action="None" />
-    <Rule Id="CA1715" Action="None" />
-    <Rule Id="CA1716" Action="None" />
-    <Rule Id="CA1717" Action="None" />
-    <Rule Id="CA1720" Action="None" />
-    <Rule Id="CA1724" Action="None" />
-    <Rule Id="CA1725" Action="None" />
-    <Rule Id="CA1815" Action="None" />
-    <Rule Id="CA1819" Action="None" />
-    <Rule Id="CA2211" Action="None" />
-    <Rule Id="CA2217" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.ApiDesignGuidelines.CSharp.Analyzers" RuleNamespace="Microsoft.ApiDesignGuidelines.CSharp.Analyzers">
-    <Rule Id="CA1001" Action="None" />
-    <Rule Id="CA1019" Action="Warning" />
-    <Rule Id="CA1032" Action="None" />
-    <Rule Id="CA1040" Action="None" />
-    <Rule Id="CA1726" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.Maintainability.Analyzers" RuleNamespace="Microsoft.Maintainability.Analyzers">
-    <Rule Id="CA1806" Action="None" />
-    <Rule Id="CA1823" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.Maintainability.CSharp.Analyzers" RuleNamespace="Microsoft.Maintainability.CSharp.Analyzers">
-    <Rule Id="CA1812" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.QualityGuidelines.Analyzers" RuleNamespace="Microsoft.QualityGuidelines.Analyzers">
-    <Rule Id="CA2214" Action="None" />
-  </Rules>
   <Rules AnalyzerId="Microsoft.QualityGuidelines.CSharp.Analyzers" RuleNamespace="Microsoft.QualityGuidelines.CSharp.Analyzers">
     <Rule Id="CA2000" Action="None" />
     <Rule Id="CA2109" Action="None" />
-    <Rule Id="CA2200" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="NationalInstruments.LabVIEW.Tools.Analyzers" RuleNamespace="NationalInstruments.LabVIEW.Tools.Analyzers">
     <Rule Id="NI1006" Action="None" />
@@ -127,21 +69,6 @@
   </Rules>
   <Rules AnalyzerId="System.Resources.CSharp.Analyzers" RuleNamespace="System.Resources.CSharp.Analyzers">
     <Rule Id="CA1824" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">
-    <Rule Id="CA1304" Action="None" />
-    <Rule Id="CA1305" Action="None" />
-    <Rule Id="CA1308" Action="None" />
-    <Rule Id="CA1813" Action="None" />
-    <Rule Id="CA1816" Action="None" />
-    <Rule Id="CA1820" Action="None" />
-    <Rule Id="CA2002" Action="None" />
-    <Rule Id="CA2208" Action="None" />
-    <Rule Id="CA2242" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="System.Runtime.CSharp.Analyzers" RuleNamespace="System.Runtime.CSharp.Analyzers">
-    <Rule Id="CA1810" Action="None" />
-    <Rule Id="CA2201" Action="None" />
   </Rules>
   <Rules AnalyzerId="NationalInstruments.Tools.Analyzers.Naming" RuleNamespace="NationalInstruments.Tools.Analyzers.Naming">
     <Rule Id="NI1704" Action="None" />

--- a/rulesets/NI.TestUtilities.ruleset
+++ b/rulesets/NI.TestUtilities.ruleset
@@ -62,13 +62,6 @@
     <Rule Id="CA2217" Action="None" />
     <Rule Id="CA2235" Action="None" />
     <Rule Id="CA2242" Action="None" />
-    <Rule Id="LRA004" Action="None" />
-    <Rule Id="LRE003" Action="None" />
-    <Rule Id="LRF003" Action="None" />
-    <Rule Id="LRF005" Action="None" />
-    <Rule Id="LRT015" Action="None" />
-    <Rule Id="LRT017" Action="None" />
-    <Rule Id="LRT018" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="Desktop.Analyzers" RuleNamespace="Desktop.Analyzers">
     <Rule Id="CA2235" Action="None" />

--- a/rulesets/NI.Tests.ruleset
+++ b/rulesets/NI.Tests.ruleset
@@ -9,9 +9,7 @@
     <Rule Id="CA1008" Action="None" />
     <Rule Id="CA1017" Action="None" />
     <Rule Id="CA1018" Action="None" />
-    <Rule Id="CA1019" Action="Warning" />
     <Rule Id="CA1024" Action="None" />
-    <Rule Id="CA1026" Action="None" />
     <Rule Id="CA1027" Action="None" />
     <Rule Id="CA1030" Action="None" />
     <Rule Id="CA1032" Action="None" />
@@ -24,11 +22,8 @@
     <Rule Id="CA1304" Action="None" />
     <Rule Id="CA1305" Action="None" />
     <Rule Id="CA1308" Action="None" />
-    <Rule Id="CA1405" Action="None" />
-    <Rule Id="CA1702" Action="None" />
     <Rule Id="CA1704" Action="None" />
     <Rule Id="CA1707" Action="None" />
-    <Rule Id="CA1709" Action="None" />
     <Rule Id="CA1710" Action="None" />
     <Rule Id="CA1711" Action="None" />
     <Rule Id="CA1712" Action="None" />
@@ -50,11 +45,8 @@
     <Rule Id="CA1824" Action="None" />
     <Rule Id="CA2001" Action="None" />
     <Rule Id="CA2002" Action="None" />
-    <Rule Id="CA2004" Action="None" />
     <Rule Id="CA2008" Action="None" />
-    <Rule Id="CA2105" Action="None" />
     <Rule Id="CA2201" Action="None" />
-    <Rule Id="CA2202" Action="None" />
     <Rule Id="CA2208" Action="None" />
     <Rule Id="CA2211" Action="None" />
     <Rule Id="CA2213" Action="None" />
@@ -63,85 +55,13 @@
     <Rule Id="CA2235" Action="None" />
     <Rule Id="CA2242" Action="None" />
   </Rules>
-  <Rules AnalyzerId="Desktop.Analyzers" RuleNamespace="Desktop.Analyzers">
-    <Rule Id="CA2235" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.ApiDesignGuidelines.Analyzers" RuleNamespace="Microsoft.ApiDesignGuidelines.Analyzers">
-    <Rule Id="CA1008" Action="None" />
-    <Rule Id="CA1017" Action="None" />
-    <Rule Id="CA1018" Action="None" />
-    <Rule Id="CA1024" Action="None" />
-    <Rule Id="CA1027" Action="None" />
-    <Rule Id="CA1030" Action="None" />
-    <Rule Id="CA1034" Action="None" />
-    <Rule Id="CA1051" Action="None" />
-    <Rule Id="CA1054" Action="None" />
-    <Rule Id="CA1064" Action="None" />
-    <Rule Id="CA1065" Action="None" />
-    <Rule Id="CA1707" Action="None" />
-    <Rule Id="CA1710" Action="None" />
-    <Rule Id="CA1711" Action="None" />
-    <Rule Id="CA1712" Action="None" />
-    <Rule Id="CA1714" Action="None" />
-    <Rule Id="CA1715" Action="None" />
-    <Rule Id="CA1716" Action="None" />
-    <Rule Id="CA1717" Action="None" />
-    <Rule Id="CA1720" Action="None" />
-    <Rule Id="CA1724" Action="None" />
-    <Rule Id="CA1725" Action="None" />
-    <Rule Id="CA1815" Action="None" />
-    <Rule Id="CA1819" Action="None" />
-    <Rule Id="CA2211" Action="None" />
-    <Rule Id="CA2217" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.ApiDesignGuidelines.CSharp.Analyzers" RuleNamespace="Microsoft.ApiDesignGuidelines.CSharp.Analyzers">
-    <Rule Id="CA1001" Action="None" />
-    <Rule Id="CA1019" Action="Warning" />
-    <Rule Id="CA1032" Action="None" />
-    <Rule Id="CA1040" Action="None" />
-    <Rule Id="CA1726" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.Maintainability.Analyzers" RuleNamespace="Microsoft.Maintainability.Analyzers">
-    <Rule Id="CA1806" Action="None" />
-    <Rule Id="CA1823" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.Maintainability.CSharp.Analyzers" RuleNamespace="Microsoft.Maintainability.CSharp.Analyzers">
-    <Rule Id="CA1812" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.QualityGuidelines.Analyzers" RuleNamespace="Microsoft.QualityGuidelines.Analyzers">
-    <Rule Id="CA2214" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.QualityGuidelines.CSharp.Analyzers" RuleNamespace="Microsoft.QualityGuidelines.CSharp.Analyzers">
-    <Rule Id="CA2000" Action="None" />
-    <Rule Id="CA2109" Action="None" />
-    <Rule Id="CA2200" Action="Warning" />
-  </Rules>
   <Rules AnalyzerId="NationalInstruments.LabVIEW.Tools.Analyzers" RuleNamespace="NationalInstruments.LabVIEW.Tools.Analyzers">
     <Rule Id="NI1006" Action="None" />
     <Rule Id="NI1007" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <Rule Id="SA1125" Action="Warning" />
     <Rule Id="SA1604" Action="None" />
     <Rule Id="SA1611" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="System.Resources.CSharp.Analyzers" RuleNamespace="System.Resources.CSharp.Analyzers">
-    <Rule Id="CA1824" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">
-    <Rule Id="CA1304" Action="None" />
-    <Rule Id="CA1305" Action="None" />
-    <Rule Id="CA1308" Action="None" />
-    <Rule Id="CA1813" Action="None" />
-    <Rule Id="CA1816" Action="None" />
-    <Rule Id="CA1820" Action="None" />
-    <Rule Id="CA2002" Action="None" />
-    <Rule Id="CA2208" Action="None" />
-    <Rule Id="CA2242" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="System.Runtime.CSharp.Analyzers" RuleNamespace="System.Runtime.CSharp.Analyzers">
-    <Rule Id="CA1810" Action="None" />
-    <Rule Id="CA2201" Action="None" />
   </Rules>
   <Rules AnalyzerId="NationalInstruments.Tools.Analyzers.Naming" RuleNamespace="NationalInstruments.Tools.Analyzers.Naming">
     <Rule Id="NI1704" Action="None" />

--- a/rulesets/NI.Tests.ruleset
+++ b/rulesets/NI.Tests.ruleset
@@ -62,13 +62,6 @@
     <Rule Id="CA2217" Action="None" />
     <Rule Id="CA2235" Action="None" />
     <Rule Id="CA2242" Action="None" />
-    <Rule Id="LRA004" Action="None" />
-    <Rule Id="LRE003" Action="None" />
-    <Rule Id="LRF003" Action="None" />
-    <Rule Id="LRF005" Action="None" />
-    <Rule Id="LRT015" Action="None" />
-    <Rule Id="LRT017" Action="None" />
-    <Rule Id="LRT018" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="Desktop.Analyzers" RuleNamespace="Desktop.Analyzers">
     <Rule Id="CA2235" Action="None" />

--- a/rulesets/NI.ruleset
+++ b/rulesets/NI.ruleset
@@ -6,21 +6,16 @@
     <Rule Id="CA1001" Action="Warning" />
     <Rule Id="CA1002" Action="Warning" />
     <Rule Id="CA1003" Action="Warning" />
-    <Rule Id="CA1004" Action="None" />
     <Rule Id="CA1005" Action="Warning" />
-    <Rule Id="CA1007" Action="Warning" />
     <Rule Id="CA1008" Action="Warning" />
     <Rule Id="CA1010" Action="Warning" />
-    <Rule Id="CA1011" Action="None" />
     <Rule Id="CA1012" Action="Warning" />
-    <Rule Id="CA1013" Action="Warning" />
     <Rule Id="CA1014" Action="None" />
     <Rule Id="CA1016" Action="Warning" />
     <Rule Id="CA1017" Action="Warning" />
     <Rule Id="CA1018" Action="Warning" />
     <Rule Id="CA1019" Action="None" />
     <Rule Id="CA1021" Action="None" />
-    <Rule Id="CA1023" Action="Warning" />
     <Rule Id="CA1024" Action="Warning" />
     <Rule Id="CA1027" Action="Warning" />
     <Rule Id="CA1028" Action="None" />
@@ -37,15 +32,12 @@
     <Rule Id="CA1045" Action="None" />
     <Rule Id="CA1046" Action="Warning" />
     <Rule Id="CA1047" Action="Warning" />
-    <Rule Id="CA1049" Action="Warning" />
     <Rule Id="CA1050" Action="Warning" />
     <Rule Id="CA1051" Action="Warning" />
     <Rule Id="CA1052" Action="Warning" />
-    <Rule Id="CA1053" Action="Warning" />
     <Rule Id="CA1054" Action="Warning" />
     <Rule Id="CA1055" Action="Warning" />
     <Rule Id="CA1056" Action="Warning" />
-    <Rule Id="CA1057" Action="Warning" />
     <Rule Id="CA1058" Action="Warning" />
     <Rule Id="CA1060" Action="Warning" />
     <Rule Id="CA1061" Action="Warning" />
@@ -64,33 +56,18 @@
     <Rule Id="CA1308" Action="Warning" />
     <Rule Id="CA1309" Action="None" />
     <Rule Id="CA1401" Action="Warning" />
-    <Rule Id="CA1402" Action="Warning" />
-    <Rule Id="CA1403" Action="Warning" />
-    <Rule Id="CA1404" Action="Warning" />
-    <Rule Id="CA1405" Action="Warning" />
-    <Rule Id="CA1407" Action="Warning" />
-    <Rule Id="CA1408" Action="Warning" />
-    <Rule Id="CA1409" Action="Warning" />
-    <Rule Id="CA1410" Action="Warning" />
-    <Rule Id="CA1411" Action="Warning" />
-    <Rule Id="CA1412" Action="Warning" />
-    <Rule Id="CA1413" Action="Warning" />
     <Rule Id="CA1414" Action="Warning" />
-    <Rule Id="CA1415" Action="Warning" />
     <Rule Id="CA1500" Action="None" />
     <Rule Id="CA1501" Action="None" />
     <Rule Id="CA1502" Action="None" />
     <Rule Id="CA1505" Action="None" />
     <Rule Id="CA1506" Action="None" />
     <Rule Id="CA1507" Action="None" />
-    <Rule Id="CA1600" Action="Warning" />
     <Rule Id="CA1601" Action="Warning" />
     <Rule Id="CA1700" Action="Warning" />
-    <Rule Id="CA1703" Action="Warning" />
     <Rule Id="CA1704" Action="Warning" />
     <Rule Id="CA1707" Action="Warning" />
     <Rule Id="CA1708" Action="Warning" />
-    <Rule Id="CA1709" Action="Warning" />
     <Rule Id="CA1710" Action="Warning" />
     <Rule Id="CA1711" Action="Warning" />
     <Rule Id="CA1712" Action="Warning" />
@@ -99,10 +76,8 @@
     <Rule Id="CA1715" Action="Warning" />
     <Rule Id="CA1716" Action="Warning" />
     <Rule Id="CA1717" Action="None" />
-    <Rule Id="CA1719" Action="Warning" />
     <Rule Id="CA1720" Action="Warning" />
     <Rule Id="CA1721" Action="Warning" />
-    <Rule Id="CA1722" Action="Warning" />
     <Rule Id="CA1724" Action="Warning" />
     <Rule Id="CA1725" Action="Warning" />
     <Rule Id="CA1726" Action="Warning" />
@@ -122,12 +97,9 @@
     <Rule Id="CA1823" Action="Warning" />
     <Rule Id="CA1824" Action="Warning" />
     <Rule Id="CA1826" Action="None" />
-    <Rule Id="CA1900" Action="Warning" />
     <Rule Id="CA2000" Action="None" />
     <Rule Id="CA2001" Action="Warning" />
     <Rule Id="CA2002" Action="Warning" />
-    <Rule Id="CA2004" Action="Warning" />
-    <Rule Id="CA2006" Action="Warning" />
     <Rule Id="CA2008" Action="Warning" />
     <Rule Id="CA2100" Action="None" />
     <Rule Id="CA2101" Action="Warning" />
@@ -135,7 +107,6 @@
     <Rule Id="CA2119" Action="Warning" />
     <Rule Id="CA2200" Action="Warning" />
     <Rule Id="CA2201" Action="Warning" />
-    <Rule Id="CA2204" Action="None" />
     <Rule Id="CA2205" Action="Warning" />
     <Rule Id="CA2207" Action="Warning" />
     <Rule Id="CA2208" Action="Warning" />
@@ -146,9 +117,7 @@
     <Rule Id="CA2215" Action="Warning" />
     <Rule Id="CA2216" Action="None" />
     <Rule Id="CA2217" Action="Warning" />
-    <Rule Id="CA2218" Action="Warning" />
     <Rule Id="CA2219" Action="Warning" />
-    <Rule Id="CA2224" Action="Warning" />
     <Rule Id="CA2225" Action="None" />
     <Rule Id="CA2226" Action="Warning" />
     <Rule Id="CA2227" Action="None" />
@@ -167,84 +136,20 @@
     <Rule Id="CA2243" Action="None" />
   </Rules>
   <Rules AnalyzerId="Desktop.Analyzers" RuleNamespace="Desktop.Analyzers">
-    <Rule Id="CA1058" Action="Warning" />
     <Rule Id="CA2153" Action="None" />
-    <Rule Id="CA2229" Action="Warning" />
-    <Rule Id="CA2235" Action="Warning" />
-    <Rule Id="CA2237" Action="Warning" />
     <Rule Id="CA3075" Action="None" />
   </Rules>
   <Rules AnalyzerId="Desktop.CSharp.Analyzers" RuleNamespace="Desktop.CSharp.Analyzers">
-    <Rule Id="CA1300" Action="Warning" />
-    <Rule Id="CA1301" Action="Warning" />
-    <Rule Id="CA1306" Action="Warning" />
-    <Rule Id="CA2212" Action="Warning" />
-    <Rule Id="CA2232" Action="Warning" />
-    <Rule Id="CA2236" Action="Warning" />
-    <Rule Id="CA2238" Action="Warning" />
-    <Rule Id="CA2239" Action="Warning" />
-    <Rule Id="CA2240" Action="Warning" />
     <Rule Id="CA3076" Action="None" />
     <Rule Id="CA3077" Action="None" />
     <Rule Id="CA5350" Action="None" />
     <Rule Id="CA5351" Action="Error" />
   </Rules>
   <Rules AnalyzerId="Microsoft.ApiDesignGuidelines.Analyzers" RuleNamespace="Microsoft.ApiDesignGuidelines.Analyzers">
-    <Rule Id="CA1000" Action="Warning" />
-    <Rule Id="CA1008" Action="Warning" />
-    <Rule Id="CA1010" Action="Warning" />
-    <Rule Id="CA1012" Action="Warning" />
-    <Rule Id="CA1014" Action="None" />
-    <Rule Id="CA1016" Action="Warning" />
-    <Rule Id="CA1017" Action="Warning" />
-    <Rule Id="CA1018" Action="Warning" />
-    <Rule Id="CA1024" Action="Warning" />
-    <Rule Id="CA1027" Action="Warning" />
-    <Rule Id="CA1028" Action="None" />
-    <Rule Id="CA1030" Action="Warning" />
-    <Rule Id="CA1031" Action="None" />
-    <Rule Id="CA1033" Action="None" />
-    <Rule Id="CA1034" Action="Warning" />
-    <Rule Id="CA1036" Action="Warning" />
-    <Rule Id="CA1041" Action="Warning" />
-    <Rule Id="CA1043" Action="Warning" />
-    <Rule Id="CA1044" Action="Warning" />
-    <Rule Id="CA1050" Action="Warning" />
-    <Rule Id="CA1051" Action="Warning" />
-    <Rule Id="CA1052" Action="Warning" />
-    <Rule Id="CA1054" Action="Warning" />
-    <Rule Id="CA1055" Action="Warning" />
-    <Rule Id="CA1056" Action="Warning" />
-    <Rule Id="CA1060" Action="Warning" />
-    <Rule Id="CA1061" Action="Warning" />
-    <Rule Id="CA1063" Action="Warning" />
-    <Rule Id="CA1064" Action="Warning" />
-    <Rule Id="CA1065" Action="Warning" />
     <Rule Id="CA1066" Action="None" />
     <Rule Id="CA1067" Action="None" />
     <Rule Id="CA1068" Action="None" />
-    <Rule Id="CA1707" Action="Warning" />
-    <Rule Id="CA1708" Action="Warning" />
-    <Rule Id="CA1710" Action="Warning" />
-    <Rule Id="CA1711" Action="Warning" />
-    <Rule Id="CA1712" Action="Warning" />
-    <Rule Id="CA1714" Action="None" />
-    <Rule Id="CA1715" Action="Warning" />
-    <Rule Id="CA1716" Action="Warning" />
-    <Rule Id="CA1717" Action="None" />
-    <Rule Id="CA1720" Action="Warning" />
-    <Rule Id="CA1721" Action="Warning" />
-    <Rule Id="CA1724" Action="Warning" />
-    <Rule Id="CA1725" Action="Warning" />
-    <Rule Id="CA1815" Action="Warning" />
-    <Rule Id="CA1819" Action="Warning" />
     <Rule Id="CA2007" Action="None" />
-    <Rule Id="CA2211" Action="Warning" />
-    <Rule Id="CA2217" Action="Warning" />
-    <Rule Id="CA2225" Action="None" />
-    <Rule Id="CA2226" Action="Warning" />
-    <Rule Id="CA2227" Action="None" />
-    <Rule Id="CA2231" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="Microsoft.ApiDesignGuidelines.CSharp.Analyzers" RuleNamespace="Microsoft.ApiDesignGuidelines.CSharp.Analyzers">
     <Rule Id="Async001" Action="None" />
@@ -253,13 +158,6 @@
     <Rule Id="Async004" Action="None" />
     <Rule Id="Async005" Action="None" />
     <Rule Id="Async006" Action="None" />
-    <Rule Id="CA1001" Action="Warning" />
-    <Rule Id="CA1003" Action="Warning" />
-    <Rule Id="CA1019" Action="None" />
-    <Rule Id="CA1032" Action="Warning" />
-    <Rule Id="CA1040" Action="Warning" />
-    <Rule Id="CA1726" Action="Warning" />
-    <Rule Id="CA2234" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
     <Rule Id="RS1001" Action="None" />
@@ -276,15 +174,6 @@
     <Rule Id="RS1012" Action="None" />
     <Rule Id="RS1013" Action="None" />
     <Rule Id="RS1014" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.Maintainability.Analyzers" RuleNamespace="Microsoft.Maintainability.Analyzers">
-    <Rule Id="CA1801" Action="None" />
-    <Rule Id="CA1806" Action="Warning" />
-    <Rule Id="CA1823" Action="Warning" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.Maintainability.CSharp.Analyzers" RuleNamespace="Microsoft.Maintainability.CSharp.Analyzers">
-    <Rule Id="CA1500" Action="None" />
-    <Rule Id="CA1812" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="Microsoft.QualityGuidelines.Analyzers" RuleNamespace="Microsoft.QualityGuidelines.Analyzers">
     <Rule Id="CA1802" Action="None" />
@@ -541,18 +430,8 @@
     <Rule Id="CA2207" Action="Warning" />
     <Rule Id="CA2215" Action="Warning" />
   </Rules>
-  <Rules AnalyzerId="System.Runtime.InteropServices.Analyzers" RuleNamespace="System.Runtime.InteropServices.Analyzers">
-    <Rule Id="CA1401" Action="Warning" />
-    <Rule Id="CA2101" Action="Warning" />
-  </Rules>
   <Rules AnalyzerId="System.Runtime.InteropServices.CSharp.Analyzers" RuleNamespace="System.Runtime.InteropServices.CSharp.Analyzers">
-    <Rule Id="CA1414" Action="Warning" />
-    <Rule Id="CA2205" Action="Warning" />
     <Rule Id="RS0015" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="System.Security.Cryptography.Hashing.Algorithms.CSharp.Analyzers" RuleNamespace="System.Security.Cryptography.Hashing.Algorithms.CSharp.Analyzers">
-    <Rule Id="CA5350" Action="None" />
-    <Rule Id="CA5351" Action="Error" />
   </Rules>
   <Rules AnalyzerId="System.Threading.Tasks.Analyzers" RuleNamespace="System.Threading.Tasks.Analyzers">
     <Rule Id="RS0018" Action="None" />

--- a/rulesets/NI.ruleset
+++ b/rulesets/NI.ruleset
@@ -165,61 +165,6 @@
     <Rule Id="CA2241" Action="None" />
     <Rule Id="CA2242" Action="Warning" />
     <Rule Id="CA2243" Action="None" />
-    <Rule Id="LRA001" Action="None" />
-    <Rule Id="LRA002" Action="Warning" />
-    <Rule Id="LRA003" Action="Warning" />
-    <Rule Id="LRA004" Action="Warning" />
-    <Rule Id="LRA005" Action="Warning" />
-    <Rule Id="LRA006" Action="None" />
-    <Rule Id="LRA007" Action="None" />
-    <Rule Id="LRA008" Action="None" />
-    <Rule Id="LRA009" Action="None" />
-    <Rule Id="LRA010" Action="None" />
-    <Rule Id="LRA011" Action="None" />
-    <Rule Id="LRA012" Action="None" />
-    <Rule Id="LRA013" Action="None" />
-    <Rule Id="LRA014" Action="None" />
-    <Rule Id="LRE001" Action="Warning" />
-    <Rule Id="LRE002" Action="Warning" />
-    <Rule Id="LRE003" Action="Warning" />
-    <Rule Id="LRF001" Action="None" />
-    <Rule Id="LRF002" Action="Warning" />
-    <Rule Id="LRF003" Action="Warning" />
-    <Rule Id="LRF004" Action="None" />
-    <Rule Id="LRF005" Action="Warning" />
-    <Rule Id="LRM001" Action="Warning" />
-    <Rule Id="LRM002" Action="None" />
-    <Rule Id="LRM003" Action="Warning" />
-    <Rule Id="LRM004" Action="None" />
-    <Rule Id="LRM005" Action="None" />
-    <Rule Id="LRM007" Action="None" />
-    <Rule Id="LRM008" Action="Warning" />
-    <Rule Id="LRM009" Action="None" />
-    <Rule Id="LRN001" Action="Warning" />
-    <Rule Id="LRP001" Action="Warning" />
-    <Rule Id="LRP002" Action="Warning" />
-    <Rule Id="LRP003" Action="None" />
-    <Rule Id="LRP004" Action="Warning" />
-    <Rule Id="LRP005" Action="Warning" />
-    <Rule Id="LRP006" Action="None" />
-    <Rule Id="LRP007" Action="Warning" />
-    <Rule Id="LRT001" Action="Warning" />
-    <Rule Id="LRT002" Action="Warning" />
-    <Rule Id="LRT003" Action="Warning" />
-    <Rule Id="LRT004" Action="Warning" />
-    <Rule Id="LRT005" Action="Warning" />
-    <Rule Id="LRT006" Action="None" />
-    <Rule Id="LRT007" Action="None" />
-    <Rule Id="LRT008" Action="Warning" />
-    <Rule Id="LRT009" Action="Warning" />
-    <Rule Id="LRT010" Action="None" />
-    <Rule Id="LRT011" Action="Warning" />
-    <Rule Id="LRT012" Action="None" />
-    <Rule Id="LRT013" Action="Warning" />
-    <Rule Id="LRT014" Action="Warning" />
-    <Rule Id="LRT015" Action="Warning" />
-    <Rule Id="LRT017" Action="None" />
-    <Rule Id="LRT018" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="Desktop.Analyzers" RuleNamespace="Desktop.Analyzers">
     <Rule Id="CA1058" Action="Warning" />


### PR DESCRIPTION
# Justification
There were a lot of rules that are stale, lack implementation in roslyn, or were duplicated. I've cleaned up the files by trimming them down to make them smaller and easier to read/diff. The visual studio editor actually adds duplicates, but I confirmed they aren't necessary. I'm removing them to keep this file as small as possible in the near future.

# Implementation
Hand edited the  files to remove the unnecessary rules. 

# Testing
I verified this on a full build of ASW to ensure there were no build errors.