### PR TITLE
Remove property configuration

### DIFF
--- a/configuration/NI.CSharp.Analyzers.targets
+++ b/configuration/NI.CSharp.Analyzers.targets
@@ -26,11 +26,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <NI1006_BannedMethods>$(SolutionDir)\BannedMethods.xml</NI1006_BannedMethods>
-
-    <!-- TODO: Determine whether we want to use the solution directory, the project directory, or both?-->
-    <NI1704_GlobalExceptions>$(SolutionDir)\CodeAnalysisDictionary.xml</NI1704_GlobalExceptions>
-
     <!--AdditionalSpellingDictionary.dic contains the differences in words between the hunspell and Microsoft dictionaries-->
     <NI1704_AdditionalSpellingDictionary>$(NI_CodeAnalysisRuleSetDirectory)\NI1704_AdditionalSpellingDictionary.dic</NI1704_AdditionalSpellingDictionary>
   </PropertyGroup>
@@ -61,18 +56,11 @@
 
     <!-- Configuration files for our analyzers -->
     <!-- By adding the Link attribute, these files will not be shown in the Solution Explorer for .NET Core projects. -->
-    <AdditionalFiles Include="$(NI1006_BannedMethods)" Condition="Exists('$(NI1006_BannedMethods)')">
-      <Link>$(NI1006_BannedMethods)</Link>
-    </AdditionalFiles>
     <AdditionalFiles Include="$(NI1704_AdditionalSpellingDictionary)" Condition="Exists('$(NI1704_AdditionalSpellingDictionary)')">
-      <Link>$(CodeAnalysisRuleSet)</Link>
+      <Link>$(NI1704_AdditionalSpellingDictionary)</Link>
     </AdditionalFiles>
     <AdditionalFiles Include="$(CodeAnalysisRuleSet)" Condition="Exists('$(CodeAnalysisRuleSet)')">
      <Link>$(CodeAnalysisRuleSet)</Link>
-    </AdditionalFiles>
-
-    <AdditionalFiles Include="$(NI1704_GlobalExceptions)" Condition="Exists('$(NI1704_GlobalExceptions)')">
-      <Link>$(NI1704_GlobalExceptions)</Link>
     </AdditionalFiles>
   </ItemGroup>
 


### PR DESCRIPTION
# Justification
There were several properties defined in NI.CSharp.Analyzers that don't always correspond to files in consuming projects/solutions. We were making assumptions about where things live, and that isn't a good thing to do. In our main application, the additional dictionary was defined one level down in a Source directory.

Rather than have default locations for overrides, we should leave them to the clients to configure as we already supply documentation on how to use the overrides.

# Implementation
Remove properties that should be defined by the consuming project instead.
Also fixed a bug where CodeAnalysisRuleset should have been NI1704_AdditionalSpellingDictionary

# Testing
None