### PR TITLE
Jryckman/update rulesetlogic

### DIFF
--- a/src/AnalyzerConfiguration/NI.CSharp.Analyzers.targets
+++ b/src/AnalyzerConfiguration/NI.CSharp.Analyzers.targets
@@ -14,10 +14,14 @@
     <!-- The following is needed for misnamed TestUtilities that contain xaml because the generated project for the second compile appends random characters to the end of the project name -->
     <NI_IsTestUtilitiesProject Condition="'$(NI_IsTestUtilitiesProject)' != 'True' and '$(NI_IsTestProject)' != 'True'">$(MSBuildProjectName.Contains(".TestUtilities"))</NI_IsTestUtilitiesProject>
 
-    <CodeAnalysisRuleSet>$(NI_CodeAnalysisRuleSetDirectory)\NI.ruleset</CodeAnalysisRuleSet>
-    <CodeAnalysisRuleSet Condition="'$(NI_IsTestProjectCondition)' == 'True'">$(NI_CodeAnalysisRuleSetDirectory)\NI.Tests.ruleset</CodeAnalysisRuleSet>
-    <CodeAnalysisRuleSet Condition="'$(NI_IsTestUtilitiesProjectCondition)' == 'True'">$(NI_CodeAnalysisRuleSetDirectory)\NI.TestUtilities.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSetDefined>False</CodeAnalysisRuleSetDefined>
+    <CodeAnalysisRuleSetDefined Condition="'$(CodeAnalysisRuleSet)' != 'MinimumRecommendedRules.ruleset'">True</CodeAnalysisRuleSetDefined>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(CodeAnalysisRuleSetDefined)' == 'False'">
+    <CodeAnalysisRuleSet Condition="'$(NI_IsTestUtilitiesProjectCondition)' == 'True'">$(NI_CodeAnalysisRuleSetDirectory)\NI.TestUtilities.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(NI_IsTestProjectCondition)' == 'True'">$(NI_CodeAnalysisRuleSetDirectory)\NI.Tests.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>$(NI_CodeAnalysisRuleSetDirectory)\NI.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>  
 
   <PropertyGroup>
     <!-- Enable analyzers if they haven't been explicitly disabled, we're using Roslyn for CA/SA, the code needs to be validated -->

--- a/src/AnalyzerConfiguration/NI.CSharp.Analyzers.targets
+++ b/src/AnalyzerConfiguration/NI.CSharp.Analyzers.targets
@@ -15,8 +15,9 @@
     <NI_IsTestUtilitiesProject Condition="'$(NI_IsTestUtilitiesProject)' != 'True' and '$(NI_IsTestProject)' != 'True'">$(MSBuildProjectName.Contains(".TestUtilities"))</NI_IsTestUtilitiesProject>
 
     <CodeAnalysisRuleSetDefined>False</CodeAnalysisRuleSetDefined>
-    <CodeAnalysisRuleSetDefined Condition="'$(CodeAnalysisRuleSet)' != 'MinimumRecommendedRules.ruleset'">True</CodeAnalysisRuleSetDefined>
+    <CodeAnalysisRuleSetDefined Condition="'$(CodeAnalysisRuleSet)' != '' and '$(CodeAnalysisRuleSet)' != 'MinimumRecommendedRules.ruleset'">True</CodeAnalysisRuleSetDefined>
   </PropertyGroup>
+  
   <PropertyGroup Condition="'$(CodeAnalysisRuleSetDefined)' == 'False'">
     <CodeAnalysisRuleSet Condition="'$(NI_IsTestUtilitiesProjectCondition)' == 'True'">$(NI_CodeAnalysisRuleSetDirectory)\NI.TestUtilities.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSet Condition="'$(NI_IsTestProjectCondition)' == 'True'">$(NI_CodeAnalysisRuleSetDirectory)\NI.Tests.ruleset</CodeAnalysisRuleSet>

--- a/src/AnalyzerConfiguration/NI.CSharp.Analyzers.targets
+++ b/src/AnalyzerConfiguration/NI.CSharp.Analyzers.targets
@@ -46,12 +46,8 @@
     <Analyzer Include="$(PkgMicrosoft_CodeQuality_Analyzers)\analyzers\dotnet\cs\Humanizer.dll" />
 
     <!-- NI's CA analyzers -->
-    <Analyzer Include="$(NuGetPackageRoot)\ni.codeanalysis.analyzers\1.0.2\lib\netstandard1.3\NI.CodeAnalysis.Analyzers.dll"/>
-    <Analyzer Include="$(NuGetPackageRoot)\ni.codeanalysis.analyzers\1.0.2\lib\netstandard1.3\Utilities.dll"/>
-    <Analyzer Include="$(NuGetPackageRoot)\ni.codequality.analyzers\1.0.2\lib\netstandard1.3\NI.CodeQuality.Analyzers.dll"/>
-    <Analyzer Include="$(NuGetPackageRoot)\ni.codequality.analyzers\1.0.2\lib\netstandard1.3\Utilities.dll"/>
-    <Analyzer Include="$(NuGetPackageRoot)\nationalinstruments.tools.analyzers.naming\1.0.2\lib\netstandard1.3\NationalInstruments.Tools.Analyzers.Naming.dll"/>
-    <Analyzer Include="$(NuGetPackageRoot)\nationalinstruments.tools.analyzers.naming\1.0.2\lib\netstandard1.3\NationalInstruments.Tools.Analyzers.Utilities.dll"/>
+    <Analyzer Include="$(PkgNI_CSharp_Analyzers)\lib\netstandard1.3\NationalInstruments.Analyzers.Utilities.dll"/>
+    <Analyzer Include="$(PkgNI_CSharp_Analyzers)\lib\netstandard1.3\NationalInstruments.Analyzers.dll"/>
 
     <!-- Configuration files for our analyzers -->
     <!-- By adding the Link attribute, these files will not be shown in the Solution Explorer for .NET Core projects. -->


### PR DESCRIPTION
# Justification
There was a bug in the .targets file where it was always going to set NI.ruleset as the ruleset because it runs after the csproj defines a <CodeAnalysisRuleSet>. 

# Implementation
The update now checks to see if the ruleset is the default and only override it if it is.

# Testing
Hand testing with custom projects to verify it works