### PR TITLE
Enforce "Do not use LINQ query syntax" using Roslyn

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ If your project starts with `TestUtilities.` or `!TestUtilities.`, the `NI.TestU
   - [[L.12] Properties and Methods](#l12-properties-and-methods)
     - [[L.12.1] ❌ **DO NOT** Introduce side effects when calling properties](#l121--do-not-introduce-side-effects-when-calling-properties)
     - [[L.12.2] ❌ **DO NOT** Allocate each time a property is called](#l122--do-not-allocate-each-time-a-property-is-called)
+  - [[L.13] ❌ **DO NOT** Use LINQ query syntax](#l13--do-not-use-linq-query-syntax)
 - [Documentation and Comments](#documentation-and-comments)
   - [[D.1] ✔️ **DO** Document public and protected members of APIs](#d1-️-do-document-public-and-protected-members-of-apis)
       - [Public API Documentation Example](#public-api-documentation-example)
@@ -1074,6 +1075,29 @@ public Foo CurrentFoo
 
         return _currentFoo;
     }
+}
+```
+
+## [L.13] ❌ **DO NOT** Use LINQ query syntax
+
+Do not use query/SQL syntax for LINQ expressions; use method/object syntax instead.
+Having only one way to read/write LINQ expressions increases consistency in our code.
+
+```csharp
+// Bad - do not use query syntax for LINQ expressions
+public void Foo()
+{
+    var someEnumerableItems = new[] { 1, 2, 3 };
+    var queryResult = from item in someEnumerableItems
+                      where item > 1
+                      select item;
+}
+
+// Good - use method syntax for LINQ expressions
+public void Foo()
+{
+    var someEnumerableItems = new[] { 1, 2, 3 };
+    var queryResult = someEnumerableItems.Where(item => item > 1);
 }
 ```
 

--- a/src/NationalInstruments.Analyzers/Properties/Resources.Designer.cs
+++ b/src/NationalInstruments.Analyzers/Properties/Resources.Designer.cs
@@ -620,6 +620,24 @@ namespace NationalInstruments.Analyzers.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Do not use LINQ query syntax; use method syntax instead..
+        /// </summary>
+        internal static string NI1018_Message {
+            get {
+                return ResourceManager.GetString("NI1018_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not use LINQ query syntax..
+        /// </summary>
+        internal static string NI1018_Title {
+            get {
+                return ResourceManager.GetString("NI1018_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0}.
         /// </summary>
         internal static string ParseError_Message {

--- a/src/NationalInstruments.Analyzers/Properties/Resources.resx
+++ b/src/NationalInstruments.Analyzers/Properties/Resources.resx
@@ -345,4 +345,10 @@
   <data name="IdentifiersShouldBeSpelledCorrectlyTitle" xml:space="preserve">
     <value>Identifiers should be spelled correctly</value>
   </data>
+  <data name="NI1018_Message" xml:space="preserve">
+    <value>Do not use LINQ query syntax; use method syntax instead.</value>
+  </data>
+  <data name="NI1018_Title" xml:space="preserve">
+    <value>Do not use LINQ query syntax.</value>
+  </data>
 </root>

--- a/src/NationalInstruments.Analyzers/Style/DoNotUseLinqQuerySyntax/DoNotUseLinqQuerySyntaxAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Style/DoNotUseLinqQuerySyntax/DoNotUseLinqQuerySyntaxAnalyzer.cs
@@ -1,0 +1,41 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NationalInstruments.Analyzers.Properties;
+using NationalInstruments.Analyzers.Utilities;
+using NationalInstruments.Analyzers.Utilities.Extensions;
+
+namespace NationalInstruments.Analyzers.Style.DoNotUseLinqQuerySyntax
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class DoNotUseLinqQuerySyntaxAnalyzer : NIDiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = "NI1018";
+
+        public static DiagnosticDescriptor Rule { get; } = new DiagnosticDescriptor(
+            DiagnosticId,
+            new LocalizableResourceString(nameof(Resources.NI1018_Title), Resources.ResourceManager, typeof(Resources)),
+            new LocalizableResourceString(nameof(Resources.NI1018_Message), Resources.ResourceManager, typeof(Resources)),
+            Resources.CategoryNI,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecutionIf(IsRunningInProduction);
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterSyntaxNodeAction(AnalyzeQueryExpression, SyntaxKind.QueryExpression);
+        }
+
+        private void AnalyzeQueryExpression(SyntaxNodeAnalysisContext context)
+        {
+            var syntaxNode = context.Node;
+            var diagnostic = Diagnostic.Create(Rule, syntaxNode.GetLocation());
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+}

--- a/src/NationalInstruments.Analyzers/Style/DoNotUseLinqQuerySyntax/DoNotUseLinqQuerySyntaxCodeFixProvider.cs
+++ b/src/NationalInstruments.Analyzers/Style/DoNotUseLinqQuerySyntax/DoNotUseLinqQuerySyntaxCodeFixProvider.cs
@@ -1,0 +1,51 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Text;
+using NationalInstruments.Tools.Analyzers.Style.DoNotUseLinqQuerySyntax;
+
+namespace NationalInstruments.Analyzers.Style.DoNotUseLinqQuerySyntax
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(DoNotUseLinqQuerySyntaxCodeFixProvider))]
+    [Shared]
+    public sealed class DoNotUseLinqQuerySyntaxCodeFixProvider : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DoNotUseLinqQuerySyntaxAnalyzer.DiagnosticId);
+
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                var codeAction = CodeAction.Create(
+                    "Rewrite LINQ expression using method syntax",
+                    cancellationToken => RewriteLinqSyntaxAsync(context.Document, diagnostic.Location.SourceSpan, cancellationToken),
+                    equivalenceKey: nameof(DoNotUseLinqQuerySyntaxCodeFixProvider));
+
+                context.RegisterCodeFix(codeAction, diagnostic);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private static async Task<Document> RewriteLinqSyntaxAsync(Document document, TextSpan sourceSpan, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+            var rewriter = new QueryComprehensionToFluentRewriter(semanticModel);
+            var oldExpression = root.FindNode(sourceSpan, getInnermostNodeForTie: true);
+            var newExpression = rewriter.Visit(oldExpression);
+            editor.ReplaceNode(oldExpression, newExpression);
+
+            return editor.GetChangedDocument();
+        }
+    }
+}

--- a/src/NationalInstruments.Analyzers/Style/DoNotUseLinqQuerySyntax/QueryComprehensionToFluentRewriter.cs
+++ b/src/NationalInstruments.Analyzers/Style/DoNotUseLinqQuerySyntax/QueryComprehensionToFluentRewriter.cs
@@ -1,0 +1,657 @@
+// https://github.com/dudikeleti/Roslyn
+// Copyright (c) 2016 Dudi Keleti
+// This software is licensed subject to the MIT license, available at https://opensource.org/licenses/MIT
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace NationalInstruments.Tools.Analyzers.Style.DoNotUseLinqQuerySyntax
+{
+    public class QueryComprehensionToFluentRewriter : CSharpSyntaxRewriter
+    {
+        private readonly SemanticModel _model;
+        private readonly QueryState _state;
+        private readonly List<InvocationExpressionSyntax> _pendingInvocationExpressions;
+        private readonly RangeVariablesComparer _rangeVariablesComparer = new RangeVariablesComparer();
+        private bool _visitInvocation = true;
+        private bool _visitQuerySyntax = true;
+
+        public QueryComprehensionToFluentRewriter(SemanticModel model)
+        {
+            _model = model;
+            _pendingInvocationExpressions = new List<InvocationExpressionSyntax>();
+            _state = new QueryState();
+        }
+
+        public override SyntaxNode VisitQueryExpression(QueryExpressionSyntax node)
+        {
+            if (!_visitQuerySyntax)
+            {
+                return base.VisitQueryExpression(node);
+            }
+
+            SetAnonymousTypeName(node);
+
+            VisitFromClause(node.FromClause);
+
+            VisitQueryBody(node.Body);
+
+            ExpressionSyntax currentExpression = ParenthesizedExpression((InvocationExpressionSyntax)_state.FluentExpression);
+
+            foreach (var invocation in _pendingInvocationExpressions.AsEnumerable().Reverse())
+            {
+                var fluentNode = InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        currentExpression,
+                        ((MemberAccessExpressionSyntax)invocation.Expression).Name),
+                    invocation.ArgumentList);
+
+                currentExpression = fluentNode;
+            }
+
+            _pendingInvocationExpressions.Clear();
+            _state.IsAnonymousType = false;
+
+            return _state.FluentExpression;
+        }
+
+        public override SyntaxNode VisitQueryBody(QueryBodySyntax node)
+        {
+            if (!_visitQuerySyntax)
+            {
+                return base.VisitQueryBody(node);
+            }
+
+            _visitInvocation = false;
+
+            // Visit each clause
+            // Concat the result to create a Fluent query expression
+            VisitClauses(node.Clauses);
+            VisitClauses(new SyntaxNode[] { node.SelectOrGroup });
+
+            // If we have a continuation ("into"),
+            // handle it like it belong to the previous clause, and continue to visit his body.
+            // Otherwise return the the fluent expression.
+            if (node.Continuation != null)
+            {
+                VisitQueryContinuation(node.Continuation);
+            }
+
+            return node;
+        }
+
+        public override SyntaxNode VisitQueryContinuation(QueryContinuationSyntax node)
+        {
+            if (!_visitQuerySyntax)
+            {
+                return base.VisitQueryContinuation(node);
+            }
+
+            _state.Reset(node);
+            VisitQueryBody(node.Body);
+            return node;
+        }
+
+        public override SyntaxNode VisitFromClause(FromClauseSyntax node)
+        {
+            if (!_visitQuerySyntax)
+            {
+                return base.VisitFromClause(node);
+            }
+
+            var temp = _visitInvocation;
+            _visitInvocation = false;
+            var newFrom = (FromClauseSyntax)base.VisitFromClause(node);
+            _visitInvocation = temp;
+
+            _state.SourceIdentifier = newFrom.Identifier;
+            _state.IdentifiersChain[_state.SourceIdentifier.ValueText] = 0;
+
+            ExpressionSyntax source = GetQuerySource(newFrom) ?? newFrom.Expression;
+
+            ExpressionSyntax fluentExpression = newFrom.Expression;
+
+            if (newFrom.Type != null)
+            {
+                var typeList = default(SeparatedSyntaxList<TypeSyntax>);
+                typeList = typeList.Add(newFrom.Type);
+
+                fluentExpression =
+                    InvocationExpression(
+                        MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            source,
+                            GenericName(
+                                Identifier("Cast"),
+                                TypeArgumentList(typeList))));
+
+                if (!AreEquivalent(source, newFrom.Expression))
+                {
+                    var isSourceFound = false;
+                    foreach (ExpressionSyntax expression in newFrom.Expression.
+                        DescendantNodesAndSelf().
+                        OfType<ExpressionSyntax>().
+                        Reverse())
+                    {
+                        if (!isSourceFound && !AreEquivalent(expression, source))
+                        {
+                            continue;
+                        }
+
+                        isSourceFound = true;
+                        var invocation = expression as InvocationExpressionSyntax;
+                        if (!(invocation?.Expression is MemberAccessExpressionSyntax memberAccess))
+                        {
+                            continue;
+                        }
+
+                        fluentExpression = InvocationExpression(
+                        MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            fluentExpression,
+                            memberAccess.Name)).WithArgumentList(invocation.ArgumentList);
+                    }
+                }
+            }
+
+            _state.FluentExpression = fluentExpression;
+            return newFrom;
+        }
+
+        public override SyntaxNode VisitWhereClause(WhereClauseSyntax node)
+        {
+            if (!_visitQuerySyntax)
+            {
+                return base.VisitWhereClause(node);
+            }
+
+            var condition = (ExpressionSyntax)SetFlagAndVisit(node.Condition);
+            return BuildFluentInvocation("Where", BuildSimpleLambdaExpression(condition));
+        }
+
+        public override SyntaxNode VisitLetClause(LetClauseSyntax node)
+        {
+            if (!_visitQuerySyntax)
+            {
+                return base.VisitLetClause(node);
+            }
+
+            var letExpression = (ExpressionSyntax)SetFlagAndVisit(node.Expression);
+
+            var nameEqualsExpressions =
+                new List<Tuple<NameEqualsSyntax, ExpressionSyntax>>
+                {
+                    Tuple.Create<NameEqualsSyntax, ExpressionSyntax>(
+                        null,
+                        IdentifierName(GetLambdaParameterToken(letExpression))),
+                    Tuple.Create(
+                        NameEquals(node.Identifier.ValueText),
+                        letExpression),
+                };
+
+            var selectInvocation = BuildFluentInvocation(
+                "Select",
+                BuildSimpleLambdaExpression(
+                    BuildAnonymousObject(nameEqualsExpressions)));
+
+            SetAnonymousState(node.Identifier);
+
+            return selectInvocation;
+        }
+
+        public override SyntaxNode VisitOrderByClause(OrderByClauseSyntax node)
+        {
+            if (!_visitQuerySyntax)
+            {
+                return base.VisitOrderByClause(node);
+            }
+
+            InvocationExpressionSyntax orderByInvocation;
+            if (node.Orderings.Count == 1)
+            {
+                orderByInvocation = HandleOrderByExpression(node.Orderings.Single(), true);
+            }
+            else
+            {
+                orderByInvocation = HandleOrderByExpression(node.Orderings[0], true);
+                foreach (OrderingSyntax orderingSyntax in node.Orderings.Skip(1))
+                {
+                    var invocation = HandleOrderByExpression(orderingSyntax, false);
+                    orderByInvocation =
+                        InvocationExpression(
+                            MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression,
+                                orderByInvocation,
+                                (IdentifierNameSyntax)invocation.Expression),
+                            invocation.ArgumentList);
+                }
+            }
+
+            return orderByInvocation;
+        }
+
+        public override SyntaxNode VisitJoinClause(JoinClauseSyntax node)
+        {
+            if (!_visitQuerySyntax)
+            {
+                return base.VisitJoinClause(node);
+            }
+
+            var joinClause = (JoinClauseSyntax)SetFlagAndVisit(node);
+            if (joinClause.Into == null)
+            {
+                SyntaxToken[] rangeVariables = { GetLambdaParameterToken(joinClause.LeftExpression), joinClause.Identifier };
+                var join = BuildFluentInvocation(
+                    "Join",
+                    Argument(joinClause.InExpression),
+                    Argument(BuildSimpleLambdaExpression(joinClause.LeftExpression)),
+                    Argument(BuildSimpleLambdaExpression(joinClause.RightExpression, Parameter(joinClause.Identifier))),
+                    Argument(BuildLambdaExpression(rangeVariables, BuildAnonymousObject(rangeVariables))));
+
+                SetAnonymousState(rangeVariables);
+                return join;
+            }
+            else
+            {
+                SyntaxToken[] rangeVariables = { GetLambdaParameterToken(joinClause.LeftExpression), Identifier(joinClause.Into.Identifier.ValueText) };
+                var groupJoin =
+                    BuildFluentInvocation(
+                        "GroupJoin",
+                        Argument(joinClause.InExpression),
+                        Argument(BuildSimpleLambdaExpression(joinClause.LeftExpression)),
+                        Argument(BuildSimpleLambdaExpression(joinClause.RightExpression, Parameter(joinClause.Identifier))),
+                        Argument(BuildLambdaExpression(rangeVariables, BuildAnonymousObject(rangeVariables))));
+
+                SetAnonymousState(joinClause.Into.Identifier);
+                return groupJoin;
+            }
+        }
+
+        public override SyntaxNode VisitSelectClause(SelectClauseSyntax node)
+        {
+            if (!_visitQuerySyntax)
+            {
+                return base.VisitSelectClause(node);
+            }
+
+            var selectExpression = (ExpressionSyntax)SetFlagAndVisit(node.Expression);
+            return BuildFluentInvocation("Select", BuildSimpleLambdaExpression(selectExpression));
+        }
+
+        public override SyntaxNode VisitGroupClause(GroupClauseSyntax node)
+        {
+            if (!_visitQuerySyntax)
+            {
+                return base.VisitGroupClause(node);
+            }
+
+            var newGroup = (GroupClauseSyntax)SetFlagAndVisit(node);
+            return BuildFluentInvocation(
+                "GroupBy",
+                BuildSimpleLambdaExpression(newGroup.ByExpression),
+                BuildSimpleLambdaExpression(newGroup.GroupExpression));
+        }
+
+        public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
+        {
+            if (_visitInvocation)
+            {
+                if (node.Expression is MemberAccessExpressionSyntax memberAccess && _state.FluentExpression == null)
+                {
+                    _pendingInvocationExpressions.Add(node);
+                }
+            }
+
+            return base.VisitInvocationExpression(node);
+        }
+
+        public override SyntaxNode VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
+        {
+            return _state.IsAnonymousType
+                       ? (MemberAccessExpressionSyntax)base.VisitMemberAccessExpression(node)
+                       : base.VisitMemberAccessExpression(node);
+        }
+
+        public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node)
+        {
+            return GetMemberAccessForVariable(node);
+        }
+
+        private void SetAnonymousTypeName(QueryExpressionSyntax node)
+        {
+            var rangeVariables = GetRangeVariables(node).Select(rv => rv.ValueText).ToList();
+            var defaultAnonymousTypeName = "t";
+            var anonymousTypeName = defaultAnonymousTypeName;
+            var i = 1;
+            while (rangeVariables.Any(val => val == anonymousTypeName))
+            {
+                anonymousTypeName = defaultAnonymousTypeName + i++;
+            }
+
+            _state.AnonymousTypeIdentifier = Identifier(anonymousTypeName);
+        }
+
+        private SyntaxNode SetFlagAndVisit(SyntaxNode node)
+        {
+            _visitQuerySyntax = false;
+            var result = Visit(node);
+            _visitQuerySyntax = true;
+            return result;
+        }
+
+        private void SetAnonymousState(params SyntaxToken[] identifiers)
+        {
+            IncreasChain();
+            foreach (SyntaxToken syntaxToken in identifiers)
+            {
+                _state.IdentifiersChain[syntaxToken.ValueText] = 0;
+            }
+
+            _state.IsAnonymousType = true;
+        }
+
+        private Stack<Tuple<SimpleNameSyntax, ArgumentListSyntax>> GetInvocationsNameAndArgumentsFromExpression(
+         InvocationExpressionSyntax fluentInvocation)
+        {
+            // In case of OrderBy clause we might have several invocations with member access,
+            // otherwise we just return the single invocation.
+            var invocations = new Stack<Tuple<SimpleNameSyntax, ArgumentListSyntax>>();
+            var expr = fluentInvocation.Expression;
+            var args = fluentInvocation.ArgumentList;
+            while (expr is MemberAccessExpressionSyntax syntax)
+            {
+                var memberAccess = syntax;
+                invocations.Push(Tuple.Create(memberAccess.Name, args));
+                var invocation = (InvocationExpressionSyntax)memberAccess.Expression;
+                expr = invocation.Expression;
+                args = invocation.ArgumentList;
+            }
+
+            invocations.Push(Tuple.Create((SimpleNameSyntax)expr, args));
+            return invocations;
+        }
+
+        private ExpressionSyntax GetQuerySource(FromClauseSyntax fromClause)
+        {
+            var node = fromClause.Expression;
+            ExpressionSyntax source = RemoveParenthesized(node);
+
+            if (!(node.DescendantNodesAndSelf().
+                OfType<InvocationExpressionSyntax>().
+                FirstOrDefault()?.Expression is MemberAccessExpressionSyntax memberAccess))
+            {
+                return node;
+            }
+
+            var invocations = new List<ExpressionSyntax> { node };
+            do
+            {
+                invocations.Add(memberAccess.Expression);
+                memberAccess = (memberAccess.Expression as InvocationExpressionSyntax)?.Expression as MemberAccessExpressionSyntax;
+            }
+            while (memberAccess != null);
+
+            // Add here your own logic to get the right collection source
+
+            return source;
+        }
+
+        private ExpressionSyntax RemoveParenthesized(ExpressionSyntax expression)
+        {
+            if (!(expression is ParenthesizedExpressionSyntax parenthesizedExpression))
+            {
+                return expression;
+            }
+
+            return RemoveParenthesized(parenthesizedExpression.Expression);
+        }
+
+        private InvocationExpressionSyntax CreateSelectMany(FromClauseSyntax currentFrom)
+        {
+            var expression = (ExpressionSyntax)Visit(currentFrom.Expression);
+            var lambdaParameters =
+              new List<SyntaxToken>
+              {
+                  GetLambdaParameterToken(expression),
+                  currentFrom.Identifier,
+              };
+
+            var firstLambda = BuildSimpleLambdaExpression(expression);
+            var secondLambda = BuildLambdaExpression(lambdaParameters, BuildAnonymousObject(lambdaParameters));
+            var selectMany = BuildFluentInvocation("SelectMany", firstLambda, secondLambda);
+
+            SetAnonymousState(currentFrom.Identifier);
+
+            return selectMany;
+        }
+
+        private ExpressionSyntax GetMemberAccessForVariable(IdentifierNameSyntax variable)
+        {
+            if (!(_model.GetSymbolInfo(variable).Symbol is IRangeVariableSymbol rangeVariable) ||
+                !_state.IsAnonymousType ||
+                !_state.IdentifiersChain.TryGetValue(variable.Identifier.ValueText, out var depth))
+            {
+                return variable;
+            }
+
+            var anonymousTypeNameExpression = IdentifierName(_state.AnonymousTypeIdentifier);
+            var memberAccessExpression = MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    anonymousTypeNameExpression,
+                    variable);
+            if (depth == 0)
+            {
+                return memberAccessExpression;
+            }
+
+            ExpressionSyntax pre = anonymousTypeNameExpression;
+            for (var i = 0; i < _state.IdentifiersChain[variable.Identifier.ValueText]; i++)
+            {
+                memberAccessExpression = MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    pre,
+                    anonymousTypeNameExpression);
+                pre = memberAccessExpression;
+            }
+
+            memberAccessExpression = MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    pre,
+                    variable);
+
+            return memberAccessExpression;
+        }
+
+        private void IncreasChain()
+        {
+            if (_state.IsAnonymousType)
+            {
+                foreach (var syntaxToken in _state.IdentifiersChain.Keys.ToList())
+                {
+                    _state.IdentifiersChain[syntaxToken]++;
+                }
+            }
+        }
+
+        private InvocationExpressionSyntax BuildFluentInvocation(
+            string methodName,
+            params LambdaExpressionSyntax[] expressions)
+        {
+            return InvocationExpression(
+                IdentifierName(methodName)).
+                WithArgumentList(
+                ArgumentList(
+                    SeparatedList(
+                        expressions.Select(Argument))));
+        }
+
+        private InvocationExpressionSyntax BuildFluentInvocation(
+            string methodName,
+            params ArgumentSyntax[] arguments)
+        {
+            return InvocationExpression(
+                IdentifierName(methodName)).
+                WithArgumentList(
+                ArgumentList(
+                    SeparatedList(arguments)));
+        }
+
+        private SimpleLambdaExpressionSyntax BuildSimpleLambdaExpression(ExpressionSyntax expression, ParameterSyntax parameter = null)
+        {
+            return SimpleLambdaExpression(parameter ?? GetLambdaParameter(expression), expression);
+        }
+
+        private ParenthesizedLambdaExpressionSyntax BuildLambdaExpression(
+           IEnumerable<SyntaxToken> tokens,
+           ExpressionSyntax expression)
+        {
+            return ParenthesizedLambdaExpression(ParameterList(SeparatedList(tokens.Select(Parameter))), expression);
+        }
+
+        private AnonymousObjectCreationExpressionSyntax BuildAnonymousObject(
+            IEnumerable<SyntaxToken> tokens)
+        {
+            return AnonymousObjectCreationExpression(
+                SeparatedList(
+                    tokens.Select(token =>
+                        AnonymousObjectMemberDeclarator(
+                            IdentifierName(token)))));
+        }
+
+        private AnonymousObjectCreationExpressionSyntax BuildAnonymousObject(
+            List<Tuple<NameEqualsSyntax, ExpressionSyntax>> nameEqulasAndExpression)
+        {
+            return AnonymousObjectCreationExpression(
+                SeparatedList(
+                    Enumerable.Range(0, nameEqulasAndExpression.Count).
+                    Select(
+                        index => nameEqulasAndExpression[index].Item1 == null ?
+                        AnonymousObjectMemberDeclarator(
+                            nameEqulasAndExpression[index].Item2) :
+                            AnonymousObjectMemberDeclarator(
+                                nameEqulasAndExpression[index].Item1,
+                                nameEqulasAndExpression[index].Item2))));
+        }
+
+        private ParameterSyntax GetLambdaParameter(ExpressionSyntax expression)
+        {
+            return Parameter(
+                GetLambdaParameterToken(expression));
+        }
+
+        private SyntaxToken GetLambdaParameterToken(ExpressionSyntax expression)
+        {
+            return _state.IsAnonymousType ?
+                _state.AnonymousTypeIdentifier :
+                GetRangeVariable(expression);
+        }
+
+        private SyntaxToken GetRangeVariable(ExpressionSyntax node)
+        {
+            try
+            {
+                return Identifier(
+                    node.DescendantNodesAndSelf().
+                    Select(n => _model.GetSymbolInfo(n).Symbol).
+                    SingleOrDefault(n => n is IRangeVariableSymbol)?.Name);
+            }
+            catch (Exception)
+            {
+                return Identifier(_state.SourceIdentifier.ValueText);
+            }
+        }
+
+        private IEnumerable<SyntaxToken> GetRangeVariables(params SyntaxNode[] nodes)
+        {
+            return (from node in nodes
+                    from child in node.DescendantNodesAndSelf()
+                    select _model.GetSymbolInfo(child).Symbol ??
+                           _model.GetDeclaredSymbol(child) into symbol
+                    where symbol is IRangeVariableSymbol
+                    select Identifier(symbol.Name)).Distinct(_rangeVariablesComparer);
+        }
+
+        private void VisitClauses(IEnumerable<SyntaxNode> clauses)
+        {
+            foreach (SyntaxNode clause in clauses)
+            {
+                // if we have from clause here, it's SelecetMany
+
+                InvocationExpressionSyntax fluentInvocation =
+                    clause is FromClauseSyntax fromClauseSyntax ?
+                    CreateSelectMany(fromClauseSyntax) :
+                    (InvocationExpressionSyntax)Visit(clause);
+
+                // Get the invocation parts of the expression
+                var simpleNameAndArgumentsTuple = GetInvocationsNameAndArgumentsFromExpression(fluentInvocation);
+
+                foreach (Tuple<SimpleNameSyntax, ArgumentListSyntax> tuple in simpleNameAndArgumentsTuple)
+                {
+                    _state.FluentExpression =
+                        InvocationExpression(
+                            MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression,
+                                _state.FluentExpression,
+                                tuple.Item1),
+                            tuple.Item2);
+                }
+            }
+        }
+
+        private InvocationExpressionSyntax HandleOrderByExpression(OrderingSyntax orderingSyntax, bool firstOrderExpression)
+        {
+            var orderExpression = (ExpressionSyntax)SetFlagAndVisit(orderingSyntax.Expression);
+
+            var orderByThenBy = firstOrderExpression ? "OrderBy" : "ThenBy";
+            orderByThenBy += orderingSyntax.AscendingOrDescendingKeyword.ValueText?.ToLower() == "descending"
+                                 ? "Descending"
+                                 : string.Empty;
+
+            InvocationExpressionSyntax orderByInvocationvocation = BuildFluentInvocation(
+                orderByThenBy,
+                BuildSimpleLambdaExpression(orderExpression));
+
+            return orderByInvocationvocation;
+        }
+
+        private class QueryState
+        {
+            public SyntaxToken AnonymousTypeIdentifier { get; set; }
+
+            public Dictionary<string, int> IdentifiersChain { get; } = new Dictionary<string, int>();
+
+            public ExpressionSyntax FluentExpression { get; set; }
+
+            public SyntaxToken SourceIdentifier { get; set; }
+
+            public bool IsAnonymousType { get; set; }
+
+            internal void Reset(QueryContinuationSyntax node)
+            {
+                IsAnonymousType = false;
+                IdentifiersChain.Clear();
+                SourceIdentifier = node.Identifier;
+                IdentifiersChain[SourceIdentifier.ValueText] = 0;
+            }
+        }
+
+        private class RangeVariablesComparer : IEqualityComparer<SyntaxToken>
+        {
+            public bool Equals(SyntaxToken x, SyntaxToken y)
+            {
+                return x.ValueText == y.ValueText;
+            }
+
+            public int GetHashCode(SyntaxToken obj)
+            {
+                return obj.ValueText.GetHashCode();
+            }
+        }
+    }
+}

--- a/tests/NationalInstruments.Analyzers.UnitTests/DoNotUseLinqQuerySyntaxAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/DoNotUseLinqQuerySyntaxAnalyzerTests.cs
@@ -1,0 +1,86 @@
+using NationalInstruments.Analyzers.Style.DoNotUseLinqQuerySyntax;
+using NationalInstruments.Analyzers.TestUtilities;
+using NationalInstruments.Analyzers.TestUtilities.TestFiles;
+using NationalInstruments.Analyzers.TestUtilities.Verifiers;
+using Xunit;
+
+namespace NationalInstruments.Analyzers.UnitTests
+{
+    /// <summary>
+    /// Tests for <see cref="DoNotUseLinqQuerySyntaxAnalyzer"/>
+    /// </summary>
+    public sealed class DoNotUseLinqQuerySyntaxAnalyzerTests : NIDiagnosticAnalyzerWithCodeFixTests<DoNotUseLinqQuerySyntaxAnalyzer, DoNotUseLinqQuerySyntaxCodeFixProvider>
+    {
+        [Fact]
+        public void LinqMethodSyntax_NoDiagnostic()
+        {
+            var test = new AutoTestFile(
+                @"
+using System.Linq;
+
+class ClassUnderTest
+{
+    public void MethodUnderTest()
+    {
+        var enumerableItems = new[] { 1, 2, 3 };
+        var linqQuery = enumerableItems.Select(item => item);
+    }
+}");
+
+            VerifyDiagnostics(test);
+        }
+
+        [Fact]
+        public void LinqQuerySyntax_Diagnostic()
+        {
+            var test = new AutoTestFile(
+                @"
+using System.Linq;
+
+class ClassUnderTest
+{
+    public void MethodUnderTest()
+    {
+        var enumerableItems = new[] { 1, 2, 3 };
+        var linqQuery = <|>from item in enumerableItems
+                        select item;
+    }
+}",
+                new Rule(DoNotUseLinqQuerySyntaxAnalyzer.Rule));
+
+            VerifyDiagnostics(test);
+        }
+
+        [Fact]
+        public void LinqQuerySyntax_ApplyFix_NoDiagnostic()
+        {
+            var test = new AutoTestFile(
+                @"
+using System.Linq;
+
+class ClassUnderTest
+{
+    public void MethodUnderTest()
+    {
+        var enumerableItems = new[] { 1, 2, 3 };
+        var linqQuery = from item in enumerableItems select item;
+    }
+}");
+
+            var testAfterFix = new TestFile(
+                @"
+using System.Linq;
+
+class ClassUnderTest
+{
+    public void MethodUnderTest()
+    {
+        var enumerableItems = new[] { 1, 2, 3 };
+        var linqQuery = enumerableItems.Select(item => item);
+    }
+}");
+
+            VerifyFix(test, testAfterFix);
+        }
+    }
+}


### PR DESCRIPTION
# Justification
Created a new analyzer to enforce LINQ method syntax instead of LINQ query syntax.

# Implementation
- Created a new analyzer
- Created a fixer for the analyzer

# Testing
Created new unit tests to verify analyzer and fixer.