### PR TITLE
Clean up test rulesets

### DIFF
--- a/src/AnalyzerConfiguration/NI.TestUtilities.ruleset
+++ b/src/AnalyzerConfiguration/NI.TestUtilities.ruleset
@@ -3,74 +3,8 @@
   <IncludeAll Action="Warning" />
   <Include Path=".\NI.ruleset" Action="Default" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
-    <Rule Id="CA1001" Action="None" />
-    <Rule Id="CA1002" Action="None" />
-    <Rule Id="CA1005" Action="None" />
-    <Rule Id="CA1008" Action="None" />
-    <Rule Id="CA1017" Action="None" />
-    <Rule Id="CA1018" Action="None" />
-    <Rule Id="CA1024" Action="None" />
-    <Rule Id="CA1027" Action="None" />
-    <Rule Id="CA1030" Action="None" />
-    <Rule Id="CA1032" Action="None" />
-    <Rule Id="CA1040" Action="None" />
-    <Rule Id="CA1051" Action="None" />
-    <Rule Id="CA1054" Action="None" />
-    <Rule Id="CA1064" Action="None" />
-    <Rule Id="CA1065" Action="None" />
-    <Rule Id="CA1304" Action="None" />
-    <Rule Id="CA1305" Action="None" />
-    <Rule Id="CA1308" Action="None" />
-    <Rule Id="CA1704" Action="None" />
-    <Rule Id="CA1707" Action="None" />
-    <Rule Id="CA1710" Action="None" />
-    <Rule Id="CA1711" Action="None" />
-    <Rule Id="CA1712" Action="None" />
-    <Rule Id="CA1715" Action="None" />
-    <Rule Id="CA1716" Action="None" />
-    <Rule Id="CA1720" Action="None" />
-    <Rule Id="CA1724" Action="None" />
-    <Rule Id="CA1725" Action="None" />
-    <Rule Id="CA1726" Action="None" />
-    <Rule Id="CA1806" Action="None" />
-    <Rule Id="CA1810" Action="None" />
-    <Rule Id="CA1812" Action="None" />
-    <Rule Id="CA1813" Action="None" />
-    <Rule Id="CA1815" Action="None" />
-    <Rule Id="CA1816" Action="None" />
-    <Rule Id="CA1819" Action="None" />
-    <Rule Id="CA1820" Action="None" />
-    <Rule Id="CA1823" Action="None" />
-    <Rule Id="CA1824" Action="None" />
-    <Rule Id="CA2001" Action="None" />
-    <Rule Id="CA2002" Action="None" />
-    <Rule Id="CA2008" Action="None" />
-    <Rule Id="CA2201" Action="None" />
-    <Rule Id="CA2208" Action="None" />
-    <Rule Id="CA2211" Action="None" />
-    <Rule Id="CA2213" Action="None" />
-    <Rule Id="CA2214" Action="None" />
-    <Rule Id="CA2217" Action="None" />
-    <Rule Id="CA2235" Action="None" />
-    <Rule Id="CA2242" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.QualityGuidelines.CSharp.Analyzers" RuleNamespace="Microsoft.QualityGuidelines.CSharp.Analyzers">
-    <Rule Id="CA2000" Action="None" />
-    <Rule Id="CA2109" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="NationalInstruments.LabVIEW.Tools.Analyzers" RuleNamespace="NationalInstruments.LabVIEW.Tools.Analyzers">
-    <Rule Id="NI1006" Action="None" />
-    <Rule Id="NI1007" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <Rule Id="SA1125" Action="Warning" />
-    <Rule Id="SA1604" Action="None" />
-    <Rule Id="SA1611" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="System.Resources.CSharp.Analyzers" RuleNamespace="System.Resources.CSharp.Analyzers">
-    <Rule Id="CA1824" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="NationalInstruments.Tools.Analyzers.Naming" RuleNamespace="NationalInstruments.Tools.Analyzers.Naming">
-    <Rule Id="NI1704" Action="None" />
+    <Rule Id="CA1304" Action="None" /> <!-- Specify CultureInfo. Tests shouldn't have to worry about localizable strings. -->
+    <Rule Id="CA1305" Action="None" /> <!-- Specify IFormatProvider. Tests shouldn't have to worry about localizable strings. -->
+    <Rule Id="CA1040" Action="None" /> <!-- Avoid empty interfaces. Applying the mix-in pattern is an exception to this rule/ -->    
   </Rules>
 </RuleSet>

--- a/src/AnalyzerConfiguration/NI.Tests.ruleset
+++ b/src/AnalyzerConfiguration/NI.Tests.ruleset
@@ -3,6 +3,8 @@
   <IncludeAll Action="Warning" />
   <Include Path=".\NI.ruleset" Action="Default" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1304" Action="None" /> <!-- Specify CultureInfo. Tests shouldn't have to worry about localizable strings. -->
+    <Rule Id="CA1305" Action="None" /> <!-- Specify IFormatProvider. Tests shouldn't have to worry about localizable strings. -->
     <Rule Id="CA1040" Action="None" /> <!-- Avoid empty interfaces. Applying the mix-in pattern is an exception to this rule/ -->    
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">

--- a/src/AnalyzerConfiguration/NI.Tests.ruleset
+++ b/src/AnalyzerConfiguration/NI.Tests.ruleset
@@ -3,67 +3,10 @@
   <IncludeAll Action="Warning" />
   <Include Path=".\NI.ruleset" Action="Default" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
-    <Rule Id="CA1001" Action="None" />
-    <Rule Id="CA1002" Action="None" />
-    <Rule Id="CA1005" Action="None" />
-    <Rule Id="CA1008" Action="None" />
-    <Rule Id="CA1017" Action="None" />
-    <Rule Id="CA1018" Action="None" />
-    <Rule Id="CA1024" Action="None" />
-    <Rule Id="CA1027" Action="None" />
-    <Rule Id="CA1030" Action="None" />
-    <Rule Id="CA1032" Action="None" />
-    <Rule Id="CA1034" Action="None" />
-    <Rule Id="CA1040" Action="None" />
-    <Rule Id="CA1051" Action="None" />
-    <Rule Id="CA1054" Action="None" />
-    <Rule Id="CA1064" Action="None" />
-    <Rule Id="CA1065" Action="None" />
-    <Rule Id="CA1304" Action="None" />
-    <Rule Id="CA1305" Action="None" />
-    <Rule Id="CA1308" Action="None" />
-    <Rule Id="CA1704" Action="None" />
-    <Rule Id="CA1707" Action="None" />
-    <Rule Id="CA1710" Action="None" />
-    <Rule Id="CA1711" Action="None" />
-    <Rule Id="CA1712" Action="None" />
-    <Rule Id="CA1715" Action="None" />
-    <Rule Id="CA1716" Action="None" />
-    <Rule Id="CA1720" Action="None" />
-    <Rule Id="CA1724" Action="None" />
-    <Rule Id="CA1725" Action="None" />
-    <Rule Id="CA1726" Action="None" />
-    <Rule Id="CA1806" Action="None" />
-    <Rule Id="CA1810" Action="None" />
-    <Rule Id="CA1812" Action="None" />
-    <Rule Id="CA1813" Action="None" />
-    <Rule Id="CA1815" Action="None" />
-    <Rule Id="CA1816" Action="None" />
-    <Rule Id="CA1819" Action="None" />
-    <Rule Id="CA1820" Action="None" />
-    <Rule Id="CA1823" Action="None" />
-    <Rule Id="CA1824" Action="None" />
-    <Rule Id="CA2001" Action="None" />
-    <Rule Id="CA2002" Action="None" />
-    <Rule Id="CA2008" Action="None" />
-    <Rule Id="CA2201" Action="None" />
-    <Rule Id="CA2208" Action="None" />
-    <Rule Id="CA2211" Action="None" />
-    <Rule Id="CA2213" Action="None" />
-    <Rule Id="CA2214" Action="None" />
-    <Rule Id="CA2217" Action="None" />
-    <Rule Id="CA2235" Action="None" />
-    <Rule Id="CA2242" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="NationalInstruments.LabVIEW.Tools.Analyzers" RuleNamespace="NationalInstruments.LabVIEW.Tools.Analyzers">
-    <Rule Id="NI1006" Action="None" />
-    <Rule Id="NI1007" Action="None" />
+    <Rule Id="CA1040" Action="None" /> <!-- Avoid empty interfaces. Applying the mix-in pattern is an exception to this rule/ -->    
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <Rule Id="SA1604" Action="None" />
-    <Rule Id="SA1611" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="NationalInstruments.Tools.Analyzers.Naming" RuleNamespace="NationalInstruments.Tools.Analyzers.Naming">
-    <Rule Id="NI1704" Action="None" />
+    <Rule Id="SA1604" Action="None" /> <!-- Element documentation must have summary. Tests shouldn't require every public element to be documented. -->
+    <Rule Id="SA1611" Action="None" /> <!-- Element parameters must be documented. Tests shouldn't require every public element to be documented. -->
   </Rules>
 </RuleSet>


### PR DESCRIPTION
# Justification
Removed temporary, repo-specific overrides from thet rulesets. These rulesets should reflect our ideal coding conventions and not contain repo-specific tech debt. These are significantly trimmed down and shouldn't change much over time.