### PR TITLE
Update MS FxCopAnalyzers package to work on VS2019

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -64,7 +64,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis" Version="2.10.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" />
+        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.10" />
         <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.0.102" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />

--- a/build/NI.CSharp.Analyzers.nuspec
+++ b/build/NI.CSharp.Analyzers.nuspec
@@ -16,7 +16,7 @@
     <license type="file">LICENSE.txt</license>
     <dependencies>
       <group targetFramework="netstandard1.3">
-        <dependency id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.6.3" />
+        <dependency id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.10" />
         <dependency id="Microsoft.CodeQuality.Analyzers" version="2.6.3" />
         <dependency id="Microsoft.NetCore.Analyzers" version="2.6.3" />
         <dependency id="Microsoft.NetFramework.Analyzers" version="2.6.3" />

--- a/tests/NationalInstruments.Analyzers.TestUtilities.UnitTests/TestMarkupTests.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities.UnitTests/TestMarkupTests.cs
@@ -219,7 +219,7 @@ namespace My.Namespace
 
             var markers = new TestMarkup().Parse(Test, out var source);
 
-            Assert.Equal(ExpectedMarkerCount, markers.Count());
+            Assert.Equal(ExpectedMarkerCount, markers.Count);
 
             foreach (var marker in markers)
             {

--- a/tests/NationalInstruments.Analyzers.TestUtilities/Verifiers/DiagnosticVerifier.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities/Verifiers/DiagnosticVerifier.cs
@@ -274,7 +274,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
         /// <returns>The actual diagnostics.</returns>
         private IEnumerable<Diagnostic> VerifyDiagnosticResults(IEnumerable<Diagnostic> actualResults, DiagnosticAnalyzer analyzer, DiagnosticResult[] expectedResults)
         {
-            var expectedCount = expectedResults.Count();
+            var expectedCount = expectedResults.Length;
             var actualCount = actualResults.Count();
 
             if (expectedCount != actualCount)


### PR DESCRIPTION
# Justification
The version of FxCopAnalyzers we use gives false positive failures on rule 2235 in Visual Studio 2019.

# Implementation
Upgrade to 2.9.10 which is the suggested version for VS2017 v15.9 and should work with VS2019.

# Testing
I manually updated the package locally and the release build worked.