### PR TITLE
Minor changes to ApprovedNamespacesAnalyzer

### DIFF
--- a/src/NationalInstruments.Analyzers/Correctness/ApprovedNamespaceAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/ApprovedNamespaceAnalyzer.cs
@@ -33,7 +33,7 @@ namespace NationalInstruments.Analyzers.Correctness
         public static DiagnosticDescriptor ProductionRule { get; } = new DiagnosticDescriptor(
             DiagnosticId,
             new LocalizableResourceString(nameof(Resources.NI1800_Title), Resources.ResourceManager, typeof(Resources)),
-            new LocalizableResourceString(nameof(Resources.NI1800_MessageFormat), Resources.ResourceManager, typeof(Resources)),
+            new LocalizableResourceString(nameof(Resources.NI1800_Message), Resources.ResourceManager, typeof(Resources)),
             Resources.CategoryNamespaces,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
@@ -46,7 +46,7 @@ namespace NationalInstruments.Analyzers.Correctness
         public static DiagnosticDescriptor TestRule { get; } = new DiagnosticDescriptor(
             DiagnosticId,
             new LocalizableResourceString(nameof(Resources.NI1800_TestTitle), Resources.ResourceManager, typeof(Resources)),
-            new LocalizableResourceString(nameof(Resources.NI1800_TestMessageFormat), Resources.ResourceManager, typeof(Resources)),
+            new LocalizableResourceString(nameof(Resources.NI1800_TestMessage), Resources.ResourceManager, typeof(Resources)),
             Resources.CategoryNamespaces,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
@@ -168,7 +168,7 @@ namespace NationalInstruments.Analyzers.Correctness
                 return IsNamespaceNameViolatingRule(namespaceName, isTestNamespace);
             }
 
-            void ReportDiagnostic(SymbolAnalysisContext context, string namespaceName, Location location, DiagnosticDescriptor rule, string approvedNamespacesfilePath)
+            void ReportDiagnostic(SymbolAnalysisContext context, string namespaceName, Location location, DiagnosticDescriptor rule, string approvedNamespacesFilePath)
             {
                 var syntaxNode = location.SourceTree.GetRoot().FindNode(location.SourceSpan);
                 var isLeafNamespace = !(syntaxNode.Parent is QualifiedNameSyntax parent)
@@ -180,9 +180,9 @@ namespace NationalInstruments.Analyzers.Correctness
                     var nameSyntax = namespaceDeclaration.Name;
 
                     var builder = ImmutableDictionary.CreateBuilder<string, string>();
-                    builder.Add("Path", approvedNamespacesfilePath);
+                    builder.Add("Path", approvedNamespacesFilePath);
                     var properties = builder.ToImmutable();
-                    var diagnostic = Diagnostic.Create(rule, nameSyntax.GetLocation(), properties, namespaceName, approvedNamespacesfilePath);
+                    var diagnostic = Diagnostic.Create(rule, nameSyntax.GetLocation(), properties, namespaceName, approvedNamespacesFilePath);
                     context.ReportDiagnostic(diagnostic);
                 }
             }

--- a/src/NationalInstruments.Analyzers/Correctness/ApprovedNamespaceAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/ApprovedNamespaceAnalyzer.cs
@@ -33,7 +33,7 @@ namespace NationalInstruments.Analyzers.Correctness
         public static DiagnosticDescriptor ProductionRule { get; } = new DiagnosticDescriptor(
             DiagnosticId,
             new LocalizableResourceString(nameof(Resources.NI1800_Title), Resources.ResourceManager, typeof(Resources)),
-            new LocalizableResourceString(nameof(Resources.NI1800_Message), Resources.ResourceManager, typeof(Resources)),
+            new LocalizableResourceString(nameof(Resources.NI1800_MessageFormat), Resources.ResourceManager, typeof(Resources)),
             Resources.CategoryNamespaces,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
@@ -46,7 +46,7 @@ namespace NationalInstruments.Analyzers.Correctness
         public static DiagnosticDescriptor TestRule { get; } = new DiagnosticDescriptor(
             DiagnosticId,
             new LocalizableResourceString(nameof(Resources.NI1800_TestTitle), Resources.ResourceManager, typeof(Resources)),
-            new LocalizableResourceString(nameof(Resources.NI1800_TestMessage), Resources.ResourceManager, typeof(Resources)),
+            new LocalizableResourceString(nameof(Resources.NI1800_TestMessageFormat), Resources.ResourceManager, typeof(Resources)),
             Resources.CategoryNamespaces,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
@@ -107,7 +107,7 @@ namespace NationalInstruments.Analyzers.Correctness
             {
                 var symbol = context.Symbol;
                 var namespaceName = symbol.ToDisplayString();
-                if (TryGetNamespaceViolatingRule(namespaceName, out DiagnosticDescriptor rule, out string approvedNamespacesFilePath))
+                if (TryGetNamespaceViolatingRule(namespaceName, out DiagnosticDescriptor rule, out var approvedNamespacesFilePath))
                 {
                     foreach (var location in symbol.Locations)
                     {
@@ -130,7 +130,7 @@ namespace NationalInstruments.Analyzers.Correctness
                         ReportFileReadDiagnostic(approvedNamespacesFile.Path);
                     }
 
-                    _approvedNamespaces.Path = approvedNamespacesFile.Path;                   
+                    _approvedNamespaces.Path = approvedNamespacesFile.Path;
                 }
 
                 if (approvedTestNamespacesFile != null)

--- a/src/NationalInstruments.Analyzers/Correctness/ApprovedNamespaceAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/ApprovedNamespaceAnalyzer.cs
@@ -23,8 +23,6 @@ namespace NationalInstruments.Analyzers.Correctness
 
         private static readonly Regex _testNamespacePattern = new Regex(@".+(\.Tests|\.TestUtilities)");
         private static readonly SourceTextValueProvider<ApprovedNamespaces> _approvedNamespacesProvider = new SourceTextValueProvider<ApprovedNamespaces>(s => new ApprovedNamespaces(s));
-        private static string _approvedNamespacesFilePath;
-        private static string _approvedTestNamespacesFilePath;
 
         private ApprovedNamespaces _approvedNamespaces;
         private ApprovedNamespaces _approvedTestNamespaces;
@@ -89,22 +87,6 @@ namespace NationalInstruments.Analyzers.Correctness
             context.RegisterCompilationStartAction(OnCompilationStart);
         }
 
-        /// <summary>
-        /// Adds a namespace to the approved namespaces list
-        /// </summary>
-        /// <param name="namespaceName">Namespace to be approved</param>
-        internal static void ApproveNamespace(string namespaceName)
-        {
-            var namespacesFilePath = IsTestNamespace(namespaceName) ? _approvedTestNamespacesFilePath : _approvedNamespacesFilePath;
-            var lines = File.ReadAllLines(namespacesFilePath);
-            var namespaces = lines
-                    .Concat(new[] { namespaceName })
-                    .Select(x => x.Trim())
-                    .OrderBy(x => x)
-                    .Distinct();
-            File.WriteAllLines(namespacesFilePath, namespaces);
-        }
-
         private static bool IsTestNamespace(string namespaceName)
         {
             return _testNamespacePattern.IsMatch(namespaceName);
@@ -125,11 +107,11 @@ namespace NationalInstruments.Analyzers.Correctness
             {
                 var symbol = context.Symbol;
                 var namespaceName = symbol.ToDisplayString();
-                if (TryGetNamespaceViolatingRule(namespaceName, out DiagnosticDescriptor rule))
+                if (TryGetNamespaceViolatingRule(namespaceName, out DiagnosticDescriptor rule, out string approvedNamespacesFilePath))
                 {
                     foreach (var location in symbol.Locations)
                     {
-                        ReportDiagnostic(context, namespaceName, location, rule);
+                        ReportDiagnostic(context, namespaceName, location, rule, approvedNamespacesFilePath);
                     }
                 }
             }
@@ -140,7 +122,6 @@ namespace NationalInstruments.Analyzers.Correctness
                 var approvedNamespacesFile = fileProvider.GetMatchingFiles("ApprovedNamespaces.txt").FirstOrDefault();
                 var approvedTestNamespacesFile = fileProvider.GetMatchingFiles("ApprovedNamespaces.Tests.txt").FirstOrDefault();
 
-                _approvedNamespacesFilePath = null;
                 if (approvedNamespacesFile != null)
                 {
                     var sourceText = approvedNamespacesFile.GetText(compilationStartContext.CancellationToken);
@@ -149,10 +130,9 @@ namespace NationalInstruments.Analyzers.Correctness
                         ReportFileReadDiagnostic(approvedNamespacesFile.Path);
                     }
 
-                    _approvedNamespacesFilePath = approvedNamespacesFile.Path;
+                    _approvedNamespaces.Path = approvedNamespacesFile.Path;                   
                 }
 
-                _approvedTestNamespacesFilePath = null;
                 if (approvedTestNamespacesFile != null)
                 {
                     var sourceText = approvedTestNamespacesFile.GetText(compilationStartContext.CancellationToken);
@@ -160,8 +140,7 @@ namespace NationalInstruments.Analyzers.Correctness
                     {
                         ReportFileReadDiagnostic(approvedTestNamespacesFile.Path);
                     }
-
-                    _approvedTestNamespacesFilePath = approvedTestNamespacesFile.Path;
+                    _approvedTestNamespaces.Path = approvedTestNamespacesFile.Path;
                 }
 
                 void ReportFileReadDiagnostic(string filePath)
@@ -181,14 +160,15 @@ namespace NationalInstruments.Analyzers.Correctness
                         && !_approvedNamespaces.IsNamespaceApproved(namespaceName));
             }
 
-            bool TryGetNamespaceViolatingRule(string namespaceName, out DiagnosticDescriptor rule)
+            bool TryGetNamespaceViolatingRule(string namespaceName, out DiagnosticDescriptor rule, out string approvedNamespacesFilePath)
             {
                 var isTestNamespace = IsTestNamespace(namespaceName);
                 rule = isTestNamespace ? TestRule : ProductionRule;
+                approvedNamespacesFilePath = isTestNamespace ? _approvedTestNamespaces.Path : _approvedNamespaces.Path;
                 return IsNamespaceNameViolatingRule(namespaceName, isTestNamespace);
             }
 
-            void ReportDiagnostic(SymbolAnalysisContext context, string namespaceName, Location location, DiagnosticDescriptor rule)
+            void ReportDiagnostic(SymbolAnalysisContext context, string namespaceName, Location location, DiagnosticDescriptor rule, string approvedNamespacesfilePath)
             {
                 var syntaxNode = location.SourceTree.GetRoot().FindNode(location.SourceSpan);
                 var isLeafNamespace = !(syntaxNode.Parent is QualifiedNameSyntax parent)
@@ -199,15 +179,17 @@ namespace NationalInstruments.Analyzers.Correctness
                 {
                     var nameSyntax = namespaceDeclaration.Name;
 
-                    var diagnostic = Diagnostic.Create(rule, nameSyntax.GetLocation(), namespaceName);
+                    var builder = ImmutableDictionary.CreateBuilder<string, string>();
+                    builder.Add("Path", approvedNamespacesfilePath);
+                    var properties = builder.ToImmutable();
+                    var diagnostic = Diagnostic.Create(rule, nameSyntax.GetLocation(), properties, namespaceName, approvedNamespacesfilePath);
                     context.ReportDiagnostic(diagnostic);
                 }
             }
 
             bool ApprovalFilesExist()
             {
-                return !string.IsNullOrEmpty(_approvedNamespacesFilePath)
-                    || !string.IsNullOrEmpty(_approvedTestNamespacesFilePath);
+                return _approvedNamespaces is object || _approvedTestNamespaces is object;
             }
         }
 
@@ -243,6 +225,8 @@ namespace NationalInstruments.Analyzers.Correctness
                     }
                 }
             }
+
+            public string Path { get; set; }
 
             public bool IsNamespaceApproved(string namespaceName)
             {

--- a/src/NationalInstruments.Analyzers/Correctness/ApprovedNamespaceCodeFixProvider.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/ApprovedNamespaceCodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace NationalInstruments.Analyzers.Correctness
                 var namespaceName = (await location.SourceTree.GetRootAsync(context.CancellationToken).ConfigureAwait(false))
                     .FindNode(location.SourceSpan)
                     .ToString();
-                var approvedNamespacesFilePaths = diagnostic.Properties.Values;
+                var approvedNamespacesFilePaths = diagnostic.Properties.Where(kv => kv.Key.StartsWith("Path")).Select(kv => kv.Value);
                 foreach (var path in approvedNamespacesFilePaths)
                 {
                     context.RegisterCodeFix(new ApprovedNamespaceCodeAction(context, namespaceName, path), context.Diagnostics);
@@ -47,8 +47,8 @@ namespace NationalInstruments.Analyzers.Correctness
 
         private class ApprovedNamespaceCodeAction : CodeAction
         {
-            private readonly string _namespaceName;
             private readonly CodeFixContext _context;
+            private readonly string _namespaceName;
             private readonly string _approvedNamespacesFilePath;
             private readonly string _title;
 

--- a/src/NationalInstruments.Analyzers/Properties/Resources.Designer.cs
+++ b/src/NationalInstruments.Analyzers/Properties/Resources.Designer.cs
@@ -710,7 +710,7 @@ namespace NationalInstruments.Analyzers.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} is not an approved namespace. If this namespace is valid, please add it to the approved namespaces list..
+        ///   Looks up a localized string similar to {0} is not an approved namespace. If this namespace is valid, please add it to the approved namespaces list - {1}.
         /// </summary>
         internal static string NI1800_Message {
             get {
@@ -755,7 +755,7 @@ namespace NationalInstruments.Analyzers.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list.
+        ///   Looks up a localized string similar to {0} is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list - {1}.
         /// </summary>
         internal static string NI1800_TestMessage {
             get {

--- a/src/NationalInstruments.Analyzers/Properties/Resources.Designer.cs
+++ b/src/NationalInstruments.Analyzers/Properties/Resources.Designer.cs
@@ -712,9 +712,9 @@ namespace NationalInstruments.Analyzers.Properties {
         /// <summary>
         ///   Looks up a localized string similar to {0} is not an approved namespace. If this namespace is valid, please add it to the approved namespaces list - {1}.
         /// </summary>
-        internal static string NI1800_MessageFormat {
+        internal static string NI1800_Message {
             get {
-                return ResourceManager.GetString("NI1800_MessageFormat", resourceCulture);
+                return ResourceManager.GetString("NI1800_Message", resourceCulture);
             }
         }
         
@@ -757,9 +757,9 @@ namespace NationalInstruments.Analyzers.Properties {
         /// <summary>
         ///   Looks up a localized string similar to {0} is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list - {1}.
         /// </summary>
-        internal static string NI1800_TestMessageFormat {
+        internal static string NI1800_TestMessage {
             get {
-                return ResourceManager.GetString("NI1800_TestMessageFormat", resourceCulture);
+                return ResourceManager.GetString("NI1800_TestMessage", resourceCulture);
             }
         }
         

--- a/src/NationalInstruments.Analyzers/Properties/Resources.Designer.cs
+++ b/src/NationalInstruments.Analyzers/Properties/Resources.Designer.cs
@@ -683,7 +683,7 @@ namespace NationalInstruments.Analyzers.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This is not an approved namespace. If this namespace is valid, please add it to the approved namespaces list - BuildTools\CodeAnalysisRuleSet\NI1800_ApprovedNamespaces.txt..
+        ///   Looks up a localized string similar to This is not an approved namespace. If this namespace is valid, please add it to the approved namespaces list..
         /// </summary>
         internal static string NI1800_Description {
             get {
@@ -710,7 +710,7 @@ namespace NationalInstruments.Analyzers.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} is not an approved namespace. If this namespace is valid, please add it to the approved namespaces list - BuildTools\CodeAnalysisRuleSet\NI1800_ApprovedNamespaces.txt..
+        ///   Looks up a localized string similar to {0} is not an approved namespace. If this namespace is valid, please add it to the approved namespaces list..
         /// </summary>
         internal static string NI1800_Message {
             get {
@@ -746,7 +746,7 @@ namespace NationalInstruments.Analyzers.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list - BuildTools\CodeAnalysisRuleSet\NI1800_ApprovedTestNamespaces.txt..
+        ///   Looks up a localized string similar to This is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list..
         /// </summary>
         internal static string NI1800_TestDescription {
             get {
@@ -755,7 +755,7 @@ namespace NationalInstruments.Analyzers.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list - BuildTools\CodeAnalysisRuleSet\NI1800_ApprovedTestNamespaces.txt..
+        ///   Looks up a localized string similar to {0} is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list.
         /// </summary>
         internal static string NI1800_TestMessage {
             get {

--- a/src/NationalInstruments.Analyzers/Properties/Resources.Designer.cs
+++ b/src/NationalInstruments.Analyzers/Properties/Resources.Designer.cs
@@ -674,11 +674,11 @@ namespace NationalInstruments.Analyzers.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add this namespace to approved namespaces.
+        ///   Looks up a localized string similar to Add this namespace to {0}.
         /// </summary>
-        internal static string NI1800_CodeFixTitle {
+        internal static string NI1800_CodeFixTitleFormat {
             get {
-                return ResourceManager.GetString("NI1800_CodeFixTitle", resourceCulture);
+                return ResourceManager.GetString("NI1800_CodeFixTitleFormat", resourceCulture);
             }
         }
         
@@ -712,9 +712,9 @@ namespace NationalInstruments.Analyzers.Properties {
         /// <summary>
         ///   Looks up a localized string similar to {0} is not an approved namespace. If this namespace is valid, please add it to the approved namespaces list - {1}.
         /// </summary>
-        internal static string NI1800_Message {
+        internal static string NI1800_MessageFormat {
             get {
-                return ResourceManager.GetString("NI1800_Message", resourceCulture);
+                return ResourceManager.GetString("NI1800_MessageFormat", resourceCulture);
             }
         }
         
@@ -757,9 +757,9 @@ namespace NationalInstruments.Analyzers.Properties {
         /// <summary>
         ///   Looks up a localized string similar to {0} is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list - {1}.
         /// </summary>
-        internal static string NI1800_TestMessage {
+        internal static string NI1800_TestMessageFormat {
             get {
-                return ResourceManager.GetString("NI1800_TestMessage", resourceCulture);
+                return ResourceManager.GetString("NI1800_TestMessageFormat", resourceCulture);
             }
         }
         

--- a/src/NationalInstruments.Analyzers/Properties/Resources.resx
+++ b/src/NationalInstruments.Analyzers/Properties/Resources.resx
@@ -383,7 +383,7 @@
     <comment>The title of the diagnostic.</comment>
   </data>
   <data name="NI1800_Message" xml:space="preserve">
-    <value>{0} is not an approved namespace. If this namespace is valid, please add it to the approved namespaces list.</value>
+    <value>{0} is not an approved namespace. If this namespace is valid, please add it to the approved namespaces list - {1}</value>
     <comment>The format-able message the diagnostic displays.</comment>
   </data>
   <data name="NI1800_ParseError_Message" xml:space="preserve">
@@ -395,7 +395,7 @@
     <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
   <data name="NI1800_TestMessage" xml:space="preserve">
-    <value>{0} is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list</value>
+    <value>{0} is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list - {1}</value>
     <comment>The format-able message the diagnostic displays.</comment>
   </data>
   <data name="NI1800_TestTitle" xml:space="preserve">

--- a/src/NationalInstruments.Analyzers/Properties/Resources.resx
+++ b/src/NationalInstruments.Analyzers/Properties/Resources.resx
@@ -371,7 +371,7 @@
     <comment>The title of code fix</comment>
   </data>
   <data name="NI1800_Description" xml:space="preserve">
-    <value>This is not an approved namespace. If this namespace is valid, please add it to the approved namespaces list - BuildTools\CodeAnalysisRuleSet\NI1800_ApprovedNamespaces.txt.</value>
+    <value>This is not an approved namespace. If this namespace is valid, please add it to the approved namespaces list.</value>
     <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
   <data name="NI1800_FileReadErrorMessage" xml:space="preserve">
@@ -383,7 +383,7 @@
     <comment>The title of the diagnostic.</comment>
   </data>
   <data name="NI1800_Message" xml:space="preserve">
-    <value>{0} is not an approved namespace. If this namespace is valid, please add it to the approved namespaces list - BuildTools\CodeAnalysisRuleSet\NI1800_ApprovedNamespaces.txt.</value>
+    <value>{0} is not an approved namespace. If this namespace is valid, please add it to the approved namespaces list.</value>
     <comment>The format-able message the diagnostic displays.</comment>
   </data>
   <data name="NI1800_ParseError_Message" xml:space="preserve">
@@ -391,11 +391,11 @@
     <comment>The exception text caught from parsing an "additional file".</comment>
   </data>
   <data name="NI1800_TestDescription" xml:space="preserve">
-    <value>This is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list - BuildTools\CodeAnalysisRuleSet\NI1800_ApprovedTestNamespaces.txt.</value>
+    <value>This is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list.</value>
     <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
   <data name="NI1800_TestMessage" xml:space="preserve">
-    <value>{0} is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list - BuildTools\CodeAnalysisRuleSet\NI1800_ApprovedTestNamespaces.txt.</value>
+    <value>{0} is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list</value>
     <comment>The format-able message the diagnostic displays.</comment>
   </data>
   <data name="NI1800_TestTitle" xml:space="preserve">

--- a/src/NationalInstruments.Analyzers/Properties/Resources.resx
+++ b/src/NationalInstruments.Analyzers/Properties/Resources.resx
@@ -382,7 +382,7 @@
     <value>Error reading file</value>
     <comment>The title of the diagnostic.</comment>
   </data>
-  <data name="NI1800_MessageFormat" xml:space="preserve">
+  <data name="NI1800_Message" xml:space="preserve">
     <value>{0} is not an approved namespace. If this namespace is valid, please add it to the approved namespaces list - {1}</value>
     <comment>The format-able message the diagnostic displays.</comment>
   </data>
@@ -394,7 +394,7 @@
     <value>This is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list.</value>
     <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
-  <data name="NI1800_TestMessageFormat" xml:space="preserve">
+  <data name="NI1800_TestMessage" xml:space="preserve">
     <value>{0} is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list - {1}</value>
     <comment>The format-able message the diagnostic displays.</comment>
   </data>

--- a/src/NationalInstruments.Analyzers/Properties/Resources.resx
+++ b/src/NationalInstruments.Analyzers/Properties/Resources.resx
@@ -366,8 +366,8 @@
   <data name="CategoryNamespaces" xml:space="preserve">
     <value>Namespaces</value>
   </data>
-  <data name="NI1800_CodeFixTitle" xml:space="preserve">
-    <value>Add this namespace to approved namespaces</value>
+  <data name="NI1800_CodeFixTitleFormat" xml:space="preserve">
+    <value>Add this namespace to {0}</value>
     <comment>The title of code fix</comment>
   </data>
   <data name="NI1800_Description" xml:space="preserve">
@@ -382,7 +382,7 @@
     <value>Error reading file</value>
     <comment>The title of the diagnostic.</comment>
   </data>
-  <data name="NI1800_Message" xml:space="preserve">
+  <data name="NI1800_MessageFormat" xml:space="preserve">
     <value>{0} is not an approved namespace. If this namespace is valid, please add it to the approved namespaces list - {1}</value>
     <comment>The format-able message the diagnostic displays.</comment>
   </data>
@@ -394,7 +394,7 @@
     <value>This is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list.</value>
     <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
-  <data name="NI1800_TestMessage" xml:space="preserve">
+  <data name="NI1800_TestMessageFormat" xml:space="preserve">
     <value>{0} is not an approved test namespace. If this namespace is valid, please add it to the approved namespaces list - {1}</value>
     <comment>The format-able message the diagnostic displays.</comment>
   </data>

--- a/tests/NationalInstruments.Analyzers.UnitTests/ApprovedNamespaceAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/ApprovedNamespaceAnalyzerTests.cs
@@ -213,7 +213,7 @@ namespace SomeNamespace
         {
             using (var testState = new TestState())
             {
-                var test = new AutoTestFile(sampleCode, new Rule(ApprovedNamespaceAnalyzer.ProductionRule, violatingNamespace));
+                var test = new AutoTestFile(sampleCode, new Rule(ApprovedNamespaceAnalyzer.ProductionRule, violatingNamespace, testState.ApprovedNamespacesFilePath));
                 VerifyDiagnostics(test, testState.GetApprovedNamespaces());
             }
         }
@@ -261,7 +261,7 @@ namespace <?>NationalInstruments.Design.Toolbar
             using (var testState = new TestState())
             {
                 var approvedNamespaceFiles = testState.GetApprovedNamespaces();
-                var test = new AutoTestFile(sampleCode, new Rule(ApprovedNamespaceAnalyzer.ProductionRule, "NationalInstruments.Design.Toolbar"));
+                var test = new AutoTestFile(sampleCode, new Rule(ApprovedNamespaceAnalyzer.ProductionRule, "NationalInstruments.Design.Toolbar", testState.ApprovedNamespacesFilePath));
                 var testAfterFix = new AutoTestFile(sampleCode.Replace("<?>", string.Empty));
 
                 VerifyDiagnostics(test, approvedNamespaceFiles);
@@ -329,7 +329,7 @@ namespace <?>XUnity.Tests
         {
             using (var testState = new TestState())
             {
-                var test = new AutoTestFile(sampleCode, new Rule(ApprovedNamespaceAnalyzer.TestRule, violatingNamespace));
+                var test = new AutoTestFile(sampleCode, new Rule(ApprovedNamespaceAnalyzer.TestRule, violatingNamespace, testState.ApprovedTestNamespacesFilePath));
                 VerifyDiagnostics(test, testState.GetApprovedNamespaces());
             }
         }
@@ -377,7 +377,7 @@ namespace <?>NationalInstruments.Tests.Integration.SourceModel
             using (var testState = new TestState())
             {
                 var approvedNamespaceFiles = testState.GetApprovedNamespaces();
-                var test = new AutoTestFile(sampleCode, new Rule(ApprovedNamespaceAnalyzer.TestRule, "NationalInstruments.Tests.Integration.SourceModel"));
+                var test = new AutoTestFile(sampleCode, new Rule(ApprovedNamespaceAnalyzer.TestRule, "NationalInstruments.Tests.Integration.SourceModel", testState.ApprovedTestNamespacesFilePath));
                 var testAfterFix = new AutoTestFile(sampleCode.Replace("<?>", string.Empty));
 
                 VerifyDiagnostics(test, approvedNamespaceFiles);
@@ -445,7 +445,7 @@ namespace <?>XUnity.TestUtilities.Core
         {
             using (var testState = new TestState())
             {
-                var test = new AutoTestFile(sampleCode, new Rule(ApprovedNamespaceAnalyzer.TestRule, violatingNamespace));
+                var test = new AutoTestFile(sampleCode, new Rule(ApprovedNamespaceAnalyzer.TestRule, violatingNamespace, testState.ApprovedTestNamespacesFilePath));
                 VerifyDiagnostics(test, testState.GetApprovedNamespaces());
             }
         }
@@ -493,7 +493,7 @@ namespace <?>NationalInstruments.TestUtilities.SourceModel
             using (var testState = new TestState())
             {
                 var approvedNamespaceFiles = testState.GetApprovedNamespaces();
-                var test = new AutoTestFile(sampleCode, new Rule(ApprovedNamespaceAnalyzer.TestRule, "NationalInstruments.TestUtilities.SourceModel"));
+                var test = new AutoTestFile(sampleCode, new Rule(ApprovedNamespaceAnalyzer.TestRule, "NationalInstruments.TestUtilities.SourceModel", testState.ApprovedTestNamespacesFilePath));
                 var testAfterFix = new AutoTestFile(sampleCode.Replace("<?>", string.Empty));
 
                 VerifyDiagnostics(test, approvedNamespaceFiles);
@@ -518,7 +518,7 @@ namespace <?>NationalInstruments.TestUtilities.SourceModel
         private class TestState : IDisposable
         {
             private const string ApprovedNamespacesFileName = "ApprovedNamespaces.txt";
-            private const string ApprovedTestNamespacesFileName = "ApprovedNamespaces.Tests.txt";
+            private  const string ApprovedTestNamespacesFileName = "ApprovedNamespaces.Tests.txt";
             private const string ApprovedNamespaces = @"
                 NationalInstruments.Design
                 NationalInstruments.SourceModel
@@ -542,9 +542,9 @@ namespace <?>NationalInstruments.TestUtilities.SourceModel
                 Directory.CreateDirectory(_testFilesFolder);
             }
 
-            private string ApprovedNamespacesFilePath => Path.Combine(_testFilesFolder, ApprovedNamespacesFileName);
+            public string ApprovedNamespacesFilePath => Path.Combine(_testFilesFolder, ApprovedNamespacesFileName);
 
-            private string ApprovedTestNamespacesFilePath => Path.Combine(_testFilesFolder, ApprovedTestNamespacesFileName);
+            public string ApprovedTestNamespacesFilePath => Path.Combine(_testFilesFolder, ApprovedTestNamespacesFileName);
 
             public void Dispose()
             {

--- a/tests/NationalInstruments.Analyzers.UnitTests/ApprovedNamespaceAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/ApprovedNamespaceAnalyzerTests.cs
@@ -518,7 +518,7 @@ namespace <?>NationalInstruments.TestUtilities.SourceModel
         private class TestState : IDisposable
         {
             private const string ApprovedNamespacesFileName = "ApprovedNamespaces.txt";
-            private  const string ApprovedTestNamespacesFileName = "ApprovedNamespaces.Tests.txt";
+            private const string ApprovedTestNamespacesFileName = "ApprovedNamespaces.Tests.txt";
             private const string ApprovedNamespaces = @"
                 NationalInstruments.Design
                 NationalInstruments.SourceModel


### PR DESCRIPTION
# Justification
A few minor changes:

- Preview did not make in sense for this code fix. In fact it had the side effect of actually making the change when an attempt to preview was made. 
- A couple of resource strings had hardcoded file paths which does not make sense now that the analyzer is not specific to ASW repo.
- Removed a couple of static file paths. Originally used to pass information from analyzer to fixer. Found a better way to do it.

# Implementation
- Disabled preview. Created a new code action - ApprovedNamespacesCodeAction that overrides the default preview action.
- Changed the resource strings to format strings to which the path is passed.
- Used Diagnostic properties to pass in information from Analyzer to CodeFixer.
 
# Testing
Ran all the existing unit tests.