### PR TITLE
Fix Issue #51 CodeAnalysis libraries are in lib folder rather than analyzer folder

### DIFF
--- a/build/NI.CSharp.Analyzers.nuspec
+++ b/build/NI.CSharp.Analyzers.nuspec
@@ -27,7 +27,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\.binaries\Release\NationalInstruments.Analyzers\**\*.dll" target="lib" />
+    <file src="..\.binaries\Release\NationalInstruments.Analyzers\**\*.dll" target="analyzers\dotnet\cs" />
     <file src="..\src\AnalyzerConfiguration\NI.CSharp.Analyzers.targets" target="build" />
     <file src="..\src\AnalyzerConfiguration\*.ruleset" target="content" />
     <file src="..\src\AnalyzerConfiguration\NI1704_AdditionalSpellingDictionary.dic" target="content" />


### PR DESCRIPTION
Fixes #51 
Put analyzer related dlls into analyzers folder
