### PR TITLE
Fix #53 Target file was not updated to reflect change from lib folder to analyzers folder

### DIFF
--- a/build/NI.CSharp.Analyzers.nuspec
+++ b/build/NI.CSharp.Analyzers.nuspec
@@ -27,7 +27,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\.binaries\Release\NationalInstruments.Analyzers\**\*.dll" target="analyzers\dotnet\cs" />
+    <file src="..\.binaries\Release\NationalInstruments.Analyzers\netstandard1.3\*.dll" target="analyzers\dotnet\cs" />
     <file src="..\src\AnalyzerConfiguration\NI.CSharp.Analyzers.targets" target="build" />
     <file src="..\src\AnalyzerConfiguration\*.ruleset" target="content" />
     <file src="..\src\AnalyzerConfiguration\NI1704_AdditionalSpellingDictionary.dic" target="content" />

--- a/src/AnalyzerConfiguration/NI.CSharp.Analyzers.targets
+++ b/src/AnalyzerConfiguration/NI.CSharp.Analyzers.targets
@@ -50,8 +50,8 @@
     <Analyzer Include="$(PkgMicrosoft_VisualStudio_Threading_Analyzers)\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll"/>
 
     <!-- NI's CA analyzers -->
-    <Analyzer Include="$(PkgNI_CSharp_Analyzers)\lib\netstandard1.3\NationalInstruments.Analyzers.Utilities.dll"/>
-    <Analyzer Include="$(PkgNI_CSharp_Analyzers)\lib\netstandard1.3\NationalInstruments.Analyzers.dll"/>
+    <Analyzer Include="$(PkgNI_CSharp_Analyzers)\analyzers\dotnet\cs\NationalInstruments.Analyzers.Utilities.dll"/>
+    <Analyzer Include="$(PkgNI_CSharp_Analyzers)\analyzers\dotnet\cs\NationalInstruments.Analyzers.dll"/>
 
     <!-- Configuration files for our analyzers -->
     <!-- By adding the Link attribute, these files will not be shown in the Solution Explorer for .NET Core projects. -->


### PR DESCRIPTION
In the previous commit, forgot to adjust the library folder in NI.CShapr.Analyzers.nuspec.
It is corrected in this PR, and now the analyzers from NI will be directly put under the dotnet\cs folder instead of dotnet\cs\netstandard1.3