### PR TITLE
Avoid null exception when no namespace files exist

### DIFF
--- a/src/NationalInstruments.Analyzers/Correctness/ApprovedNamespaceAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/ApprovedNamespaceAnalyzer.cs
@@ -95,12 +95,15 @@ namespace NationalInstruments.Analyzers.Correctness
         private void OnCompilationStart(CompilationStartAnalysisContext compilationStartContext)
         {
             InitializeApprovedNamespaces();
-            compilationStartContext.RegisterSymbolAction(AnalyzeNamespace, SymbolKind.Namespace);
 
             if (!ApprovalFilesExist())
             {
                 var diagnostic = Diagnostic.Create(MissingApprovalFilesRule, Location.None);
                 compilationStartContext.RegisterCompilationEndAction(x => x.ReportDiagnostic(diagnostic));
+            }
+            else
+            {
+                compilationStartContext.RegisterSymbolAction(AnalyzeNamespace, SymbolKind.Namespace);
             }
 
             void AnalyzeNamespace(SymbolAnalysisContext context)

--- a/tests/NationalInstruments.Analyzers.UnitTests/ApprovedNamespaceAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/ApprovedNamespaceAnalyzerTests.cs
@@ -20,7 +20,7 @@ namespace NationalInstruments.Analyzers.UnitTests
         [Fact]
         public void MissingApprovalFiles_Verify_EmitsDiagnostic()
         {
-            VerifyDiagnostics(new TestFile("class Program { }"), GetResult(ApprovedNamespaceAnalyzer.MissingApprovalFilesRule));
+            VerifyDiagnostics(new TestFile("namespace Foo { class Program { } }"), GetResult(ApprovedNamespaceAnalyzer.MissingApprovalFilesRule));
         }
 
         [Theory]


### PR DESCRIPTION
# Justification
Prior to this commit, NI1800 would still analyze namespaces when no ApprovedNamespaces[.Tests].txt files existed. This caused a null exception as documented in issue #55.

# Implementation
Moved the code that analyzes namespace symbols behind an`if` statement that first checks that approval files exist. If they don't exist, no namespaces will be analyzed.

# Testing
Modified the "missing approval files" test to define a namespace and confirmed it failed with a null exception. Made the change described above and confirmed the test now passed.