### PR TITLE
Stop analyzing if rule NI1800 is suppress/None

### DIFF
--- a/src/NationalInstruments.Analyzers/Correctness/ApprovedNamespaceAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/ApprovedNamespaceAnalyzer.cs
@@ -94,6 +94,12 @@ namespace NationalInstruments.Analyzers.Correctness
 
         private void OnCompilationStart(CompilationStartAnalysisContext compilationStartContext)
         {
+            var effectiveSeverity = ProductionRule.GetEffectiveSeverity(compilationStartContext.Compilation.Options);
+            if (effectiveSeverity == Microsoft.CodeAnalysis.ReportDiagnostic.Suppress)
+            {
+                return;
+            }
+
             InitializeApprovedNamespaces();
 
             if (!ApprovalFilesExist())


### PR DESCRIPTION
# Justification
Per issue #57 , NI1800_ReadError shouldn't be emitted when NI1800 is disabled.

# Implementation
Get effective severity for `ProductionRule` and exit early if it's Suppress/None. We only need to check `ProductionRule` or `TestRule` since they both have the same diagnostic ID.

# Testing
Built a new version and applied it to a test project. Confirmed enabling NI1800 caused NI1800_ReadError to appear and disabling it caused NI1800_ReadError to disappear. 