### PR TITLE
Update URL within NI1006 error message

### DIFF
--- a/src/NationalInstruments.Analyzers/Correctness/DoNotUseBannedMethodsAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/DoNotUseBannedMethodsAnalyzer.cs
@@ -58,7 +58,7 @@ namespace NationalInstruments.Analyzers.Correctness
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             description: new LocalizableResourceString(nameof(Resources.NI1006_Description), Resources.ResourceManager, typeof(Resources)),
-            helpLinkUri: "https://nitalk.jiveon.com/docs/DOC-455694");
+            helpLinkUri: "https://github.com/ni/csharp-styleguide/blob/main/docs/Banned%20Methods.md");
 
         public static DiagnosticDescriptor FileParseRule { get; } = new DiagnosticDescriptor(
             DiagnosticId,


### PR DESCRIPTION
# Justification
To address an issue filed by GregR about NI1006 pointing to stale, internal documentation, I migrated the documentation to this github repo and updated the URL to point here instead.

# Implementation
Updated the URL as a part of the NI1006 error message to point to documentation on github csharp-styleguide instead of an internal NI website.

# Testing
Relying on existing CI