### PR TITLE
Fix for "NI1017 gives false positives involving array initializers"

### DIFF
--- a/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
@@ -60,9 +60,6 @@ namespace NationalInstruments.Analyzers.Style
                 .FirstOrDefault();
 
             AnalyzeInvocationExpression(invocationExpressionSyntax, context.ReportDiagnostic);
-
-            bool IsNotArrayInitializerSyntax(SyntaxNode syntaxNode) =>
-                !syntaxNode.IsKind(SyntaxKind.ArrayInitializerExpression);
         }
 
         private static void AnalyzeArrayInitializer(SyntaxNodeAnalysisContext context)
@@ -136,8 +133,8 @@ namespace NationalInstruments.Analyzers.Style
             bool IsOutOfScopeSyntax(SyntaxNode syntaxNode) => IsNotArgumentSyntax(syntaxNode) && IsNotArrayInitializerSyntax(syntaxNode);
 
             bool IsNotArgumentSyntax(SyntaxNode syntaxNode) => !syntaxNode.IsKind(SyntaxKind.Argument);
-
-            bool IsNotArrayInitializerSyntax(SyntaxNode syntaxNode) => !syntaxNode.IsKind(SyntaxKind.ArrayInitializerExpression);
         }
+
+        private static bool IsNotArrayInitializerSyntax(SyntaxNode syntaxNode) => !syntaxNode.IsKind(SyntaxKind.ArrayInitializerExpression);
     }
 }

--- a/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
@@ -91,7 +91,7 @@ namespace NationalInstruments.Analyzers.Style
 
             // Find all non-nested arguments which contain a lambda expression
             var nonNestedArgumentsWithLambdas = invocationExpressionSyntax
-                .DescendantNodes(IsNonNested)
+                .DescendantNodes(IsOutOfScopeSyntax)
                 .OfType<ArgumentListSyntax>()
                 .Where(argument => argument.DescendantNodes().Any(IsLambdaExpression));
 
@@ -133,7 +133,7 @@ namespace NationalInstruments.Analyzers.Style
 
             bool IsLambdaExpression(SyntaxNode syntaxNode) => syntaxNode.IsKind(SyntaxKind.SimpleLambdaExpression);
 
-            bool IsNonNested(SyntaxNode syntaxNode) => IsNotArgumentSyntax(syntaxNode) && IsNotArrayInitializerSyntax(syntaxNode);
+            bool IsOutOfScopeSyntax(SyntaxNode syntaxNode) => IsNotArgumentSyntax(syntaxNode) && IsNotArrayInitializerSyntax(syntaxNode);
 
             bool IsNotArgumentSyntax(SyntaxNode syntaxNode) => !syntaxNode.IsKind(SyntaxKind.Argument);
 

--- a/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
@@ -36,18 +36,18 @@ namespace NationalInstruments.Analyzers.Style
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
             context.RegisterSyntaxNodeAction(
-                AnalyzeSyntaxContext,
+                AnalyzeExpression,
                 SyntaxKind.ExpressionStatement,
                 SyntaxKind.EqualsValueClause,
                 SyntaxKind.Argument,
                 SyntaxKind.ArrowExpressionClause);
 
             context.RegisterSyntaxNodeAction(
-                AnalyzeArrayInitializerContext,
+                AnalyzeArrayInitializer,
                 SyntaxKind.ArrayInitializerExpression);
         }
 
-        private static void AnalyzeSyntaxContext(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeExpression(SyntaxNodeAnalysisContext context)
         {
             var parentSyntaxNode = context.Node;
 
@@ -65,7 +65,7 @@ namespace NationalInstruments.Analyzers.Style
                 !syntaxNode.IsKind(SyntaxKind.ArrayInitializerExpression);
         }
 
-        private static void AnalyzeArrayInitializerContext(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeArrayInitializer(SyntaxNodeAnalysisContext context)
         {
             var arrayInitializerSyntaxNode = context.Node;
 

--- a/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
@@ -67,10 +67,10 @@ namespace NationalInstruments.Analyzers.Style
 
         private static void AnalyzeArrayInitializer(SyntaxNodeAnalysisContext context)
         {
-            var arrayInitializerSyntaxNode = context.Node;
+            var arrayInitializerSyntax = context.Node;
 
             // Find only direct child invocation expressions
-            var invocationExpressions = arrayInitializerSyntaxNode
+            var invocationExpressions = arrayInitializerSyntax
                 .ChildNodes()
                 .OfType<InvocationExpressionSyntax>();
 

--- a/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
@@ -55,13 +55,14 @@ namespace NationalInstruments.Analyzers.Style
             // a method/delegate call or a property access
             // or a chain of them
             var invocationExpressionSyntax = parentSyntaxNode
-                .DescendantNodes(IsNotArrayCreationSyntax)
+                .DescendantNodes(IsNotArrayInitializerSyntax)
                 .OfType<InvocationExpressionSyntax>()
                 .FirstOrDefault();
 
             AnalyzeSyntaxNode(invocationExpressionSyntax, context.ReportDiagnostic);
 
-            bool IsNotArrayCreationSyntax(SyntaxNode syntaxNode) => !syntaxNode.IsKind(SyntaxKind.ArrayCreationExpression);
+            bool IsNotArrayInitializerSyntax(SyntaxNode syntaxNode) =>
+                !syntaxNode.IsKind(SyntaxKind.ArrayInitializerExpression);
         }
 
         private static void AnalyzeArrayInitializerContext(SyntaxNodeAnalysisContext context)

--- a/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
@@ -75,9 +75,9 @@ namespace NationalInstruments.Analyzers.Style
                 .OfType<InvocationExpressionSyntax>();
 
             // Analyze individual invocation expressions
-            foreach (var invocationExpression in invocationExpressionSyntaxes)
+            foreach (var invocationExpressionSyntax in invocationExpressionSyntaxes)
             {
-                AnalyzeInvocationExpression(invocationExpression, context.ReportDiagnostic);
+                AnalyzeInvocationExpression(invocationExpressionSyntax, context.ReportDiagnostic);
             }
         }
 

--- a/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
@@ -136,6 +136,5 @@ namespace NationalInstruments.Analyzers.Style
 
             bool IsNotArrayInitializerSyntax(SyntaxNode syntaxNode) => !syntaxNode.IsKind(SyntaxKind.ArrayInitializerExpression);
         }
-
     }
 }

--- a/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
@@ -59,7 +59,7 @@ namespace NationalInstruments.Analyzers.Style
                 .OfType<InvocationExpressionSyntax>()
                 .FirstOrDefault();
 
-            AnalyzeSyntaxNode(invocationExpressionSyntax, context.ReportDiagnostic);
+            AnalyzeInvocationExpression(invocationExpressionSyntax, context.ReportDiagnostic);
 
             bool IsNotArrayInitializerSyntax(SyntaxNode syntaxNode) =>
                 !syntaxNode.IsKind(SyntaxKind.ArrayInitializerExpression);
@@ -77,11 +77,11 @@ namespace NationalInstruments.Analyzers.Style
             // Analyze individual invocation expressions
             foreach (var invocationExpression in invocationExpressions)
             {
-                AnalyzeSyntaxNode(invocationExpression, context.ReportDiagnostic);
+                AnalyzeInvocationExpression(invocationExpression, context.ReportDiagnostic);
             }
         }
 
-        private static void AnalyzeSyntaxNode(InvocationExpressionSyntax invocationExpressionSyntax, Action<Diagnostic> reportDiagnostic)
+        private static void AnalyzeInvocationExpression(InvocationExpressionSyntax invocationExpressionSyntax, Action<Diagnostic> reportDiagnostic)
         {
             if (invocationExpressionSyntax is null)
             {

--- a/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
@@ -55,11 +55,13 @@ namespace NationalInstruments.Analyzers.Style
             // a method/delegate call or a property access
             // or a chain of them
             var invocationExpressionSyntax = parentSyntaxNode
-                .DescendantNodes()
+                .DescendantNodes(IsNotArrayCreationSyntax)
                 .OfType<InvocationExpressionSyntax>()
                 .FirstOrDefault();
 
             AnalyzeSyntaxNode(invocationExpressionSyntax, context.ReportDiagnostic);
+
+            bool IsNotArrayCreationSyntax(SyntaxNode syntaxNode) => !syntaxNode.IsKind(SyntaxKind.ArrayCreationExpression);
         }
 
         private static void AnalyzeArrayInitializerContext(SyntaxNodeAnalysisContext context)

--- a/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
@@ -63,7 +63,7 @@ namespace NationalInstruments.Analyzers.Style
 
             // Find all non-nested arguments which contain a lambda expression
             var nonNestedArgumentsWithLambdas = invocationExpressionSyntax
-                .DescendantNodes(IsNotArgumentSyntax)
+                .DescendantNodes(IsNonNested)
                 .OfType<ArgumentListSyntax>()
                 .Where(argument => argument.DescendantNodes().Any(IsLambdaExpression));
 
@@ -105,7 +105,12 @@ namespace NationalInstruments.Analyzers.Style
 
             bool IsLambdaExpression(SyntaxNode syntaxNode) => syntaxNode.IsKind(SyntaxKind.SimpleLambdaExpression);
 
+            bool IsNonNested(SyntaxNode syntaxNode) => IsNotArgumentSyntax(syntaxNode) && IsNotArrayInitializerSyntax(syntaxNode);
+
             bool IsNotArgumentSyntax(SyntaxNode syntaxNode) => !syntaxNode.IsKind(SyntaxKind.Argument);
+
+            bool IsNotArrayInitializerSyntax(SyntaxNode syntaxNode) => !syntaxNode.IsKind(SyntaxKind.ArrayInitializerExpression);
         }
+
     }
 }

--- a/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
@@ -43,7 +43,7 @@ namespace NationalInstruments.Analyzers.Style
                 SyntaxKind.ArrowExpressionClause);
 
             context.RegisterSyntaxNodeAction(
-                ArrayInitializerExpressionContext,
+                AnalyzeArrayInitializerContext,
                 SyntaxKind.ArrayInitializerExpression);
         }
 
@@ -62,11 +62,11 @@ namespace NationalInstruments.Analyzers.Style
             AnalyzeSyntaxNode(invocationExpressionSyntax, context.ReportDiagnostic);
         }
 
-        private static void ArrayInitializerExpressionContext(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeArrayInitializerContext(SyntaxNodeAnalysisContext context)
         {
             var arrayInitializerSyntaxNode = context.Node;
 
-            // Find all direct child invocation expressions
+            // Find only direct child invocation expressions
             var invocationExpressions = arrayInitializerSyntaxNode
                 .ChildNodes()
                 .OfType<InvocationExpressionSyntax>();

--- a/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Style/ChainOfMethodsWithLambdasAnalyzer.cs
@@ -70,12 +70,12 @@ namespace NationalInstruments.Analyzers.Style
             var arrayInitializerSyntax = context.Node;
 
             // Find only direct child invocation expressions
-            var invocationExpressions = arrayInitializerSyntax
+            var invocationExpressionSyntaxes = arrayInitializerSyntax
                 .ChildNodes()
                 .OfType<InvocationExpressionSyntax>();
 
             // Analyze individual invocation expressions
-            foreach (var invocationExpression in invocationExpressions)
+            foreach (var invocationExpression in invocationExpressionSyntaxes)
             {
                 AnalyzeInvocationExpression(invocationExpression, context.ReportDiagnostic);
             }

--- a/tests/NationalInstruments.Analyzers.UnitTests/ChainOfMethodsWithLambdasAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/ChainOfMethodsWithLambdasAnalyzerTests.cs
@@ -880,6 +880,51 @@ namespace NationalInstruments.Analyzers.UnitTests
 
             VerifyDiagnostics(test);
         }
+
+        [Fact]
+        public void NI1017_PoorlyLambdasJaggedArrayInitializers_EmitsDiagnostic()
+        {
+            var test = new AutoTestFile(
+@"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NationalInstruments.Analyzers.UnitTests
+{
+    class Test
+    {
+        private static ISoftwareContent[][] Foo(ISoftwareContent softwareContent)
+        {
+            var temp = new ISoftwareContent[][]
+            {
+                new[]
+                {
+                    <|>softwareContent.Children(x => false).Select(s => s).First(s => s.AliasName == ""T"")
+                },
+                new[]
+                {
+                    <|>softwareContent.Children(x => false).Select(s => s).First(s => s.AliasName == ""U"")
+                }
+            };
+            return temp;
+        }
+
+        private interface ISoftwareContent
+        {
+            IEnumerable<ISoftwareContent> Children(Predicate<int> predicate = null);
+        
+            string AliasName { get; }
+        }
+    }
+}
+",
+GetNI1017Rule(),
+GetNI1017Rule());
+
+            VerifyDiagnostics(test);
+        }
+
         private Rule GetNI1017Rule()
         {
             return new Rule(ChainOfMethodsWithLambdasAnalyzer.Rule);

--- a/tests/NationalInstruments.Analyzers.UnitTests/ChainOfMethodsWithLambdasAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/ChainOfMethodsWithLambdasAnalyzerTests.cs
@@ -677,7 +677,6 @@ namespace NationalInstruments.Analyzers.UnitTests
         {
             var test = new AutoTestFile(
 @"
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -717,7 +716,6 @@ namespace NationalInstruments.Analyzers.UnitTests
         {
             var test = new AutoTestFile(
 @"
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/tests/NationalInstruments.Analyzers.UnitTests/ChainOfMethodsWithLambdasAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/ChainOfMethodsWithLambdasAnalyzerTests.cs
@@ -715,7 +715,7 @@ GetNI1017Rule());
         }
 
         [Fact]
-        public void NI1017_WellSplitLambdasArrayInitializers_EmitsDiagnostic()
+        public void NI1017_WellSplitLambdasArrayInitializers_NoDiagnostic()
         {
             var test = new AutoTestFile(
 @"
@@ -796,7 +796,7 @@ GetNI1017Rule());
         }
 
         [Fact]
-        public void NI1017_WellSplitLambdasAlongWithArrayInitializers_EmitsDiagnostic()
+        public void NI1017_WellSplitLambdasAlongWithArrayInitializers_NoDiagnostic()
         {
             var test = new AutoTestFile(
 @"
@@ -882,7 +882,7 @@ namespace NationalInstruments.Analyzers.UnitTests
         }
 
         [Fact]
-        public void NI1017_PoorlyLambdasJaggedArrayInitializers_EmitsDiagnostic()
+        public void NI1017_PoorlySplitLambdasJaggedArrayInitializers_EmitsDiagnostic()
         {
             var test = new AutoTestFile(
 @"

--- a/tests/NationalInstruments.Analyzers.UnitTests/ChainOfMethodsWithLambdasAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/ChainOfMethodsWithLambdasAnalyzerTests.cs
@@ -707,7 +707,9 @@ namespace NationalInstruments.Analyzers.UnitTests
         }
     }
 }
-", GetNI1017Rule(), GetNI1017Rule());
+",
+GetNI1017Rule(),
+GetNI1017Rule());
 
             VerifyDiagnostics(test);
         }
@@ -786,7 +788,9 @@ namespace NationalInstruments.Analyzers.UnitTests
         }
     }
 }
-", GetNI1017Rule(), GetNI1017Rule());
+",
+GetNI1017Rule(),
+GetNI1017Rule());
 
             VerifyDiagnostics(test);
         }

--- a/tests/NationalInstruments.Analyzers.UnitTests/ChainOfMethodsWithLambdasAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/ChainOfMethodsWithLambdasAnalyzerTests.cs
@@ -835,6 +835,51 @@ namespace NationalInstruments.Analyzers.UnitTests
             VerifyDiagnostics(test);
         }
 
+        [Fact]
+        public void NI1017_WellSplitLambdasJaggedArrayInitializers_NoDiagnostic()
+        {
+            var test = new AutoTestFile(
+@"
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NationalInstruments.Analyzers.UnitTests
+{
+    class Test
+    {
+        private static int Foo(IEnumerable<int> numbers)
+        {
+            var temp = new int[][]
+            {
+                new[]
+                {
+                numbers.Count(number => number == 1),
+                numbers.Count(number => number == 2),
+                numbers.Count(number => number == 3)
+                },
+
+                new[]
+                {
+                numbers.Count(number => number == 1),
+                numbers.Count(number => number == 2),
+                numbers.Count(number => number == 3)
+                },
+
+                new[]
+                {
+                numbers.Count(number => number == 1),
+                numbers.Count(number => number == 2),
+                numbers.Count(number => number == 3)
+                },
+            };
+            return 42;
+        }
+    }
+}
+");
+
+            VerifyDiagnostics(test);
+        }
         private Rule GetNI1017Rule()
         {
             return new Rule(ChainOfMethodsWithLambdasAnalyzer.Rule);


### PR DESCRIPTION
# Justification
#46

# Implementation
Array initializers can have individual invocation expressions separated by commas instead of ".". Tweaked the logic of the analyzer to handle array initializers separately - only looking at direct child nodes of an array initializer and handling individual invocation expressions within the array initializer.

# Testing
- Existing tests pass.
- New tests pass.