### PR TITLE
Fix violations that occur with new analyzers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,9 +44,6 @@
 
     <PropertyGroup>
         <IncludeCompatabilityAnalyzer Condition=" '$(IncludeCompatabilityAnalyzer)' == '' ">True</IncludeCompatabilityAnalyzer>
-        <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-        <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
-        <RunAnalyzers>true</RunAnalyzers>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,21 +44,20 @@
 
     <PropertyGroup>
         <IncludeCompatabilityAnalyzer Condition=" '$(IncludeCompatabilityAnalyzer)' == '' ">True</IncludeCompatabilityAnalyzer>
+        <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+        <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
+        <RunAnalyzers>true</RunAnalyzers>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
         <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
         <DebugType>full</DebugType>
-        <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
-        <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
-        <RunAnalyzers>false</RunAnalyzers>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
         <DefineConstants>$(DefineConstants)</DefineConstants>
         <DebugType>pdbonly</DebugType>
         <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == ''">True</TreatWarningsAsErrors>
-        <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\tools\Labview.Tools.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/NationalInstruments.Analyzers/Correctness/DoNotUseBannedMethodsAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/DoNotUseBannedMethodsAnalyzer.cs
@@ -137,7 +137,7 @@ namespace NationalInstruments.Analyzers.Correctness
 
                 foreach (XElement element in rootElement.Elements())
                 {
-                    ParseBannedMethodElement(element, default(AnalyzerEntryOptionsForParsing));
+                    ParseBannedMethodElement(element, default);
                 }
             }
 

--- a/src/NationalInstruments.Analyzers/Correctness/StringsShouldBeInResources/StringLiteralAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/StringsShouldBeInResources/StringLiteralAnalyzer.cs
@@ -152,6 +152,9 @@ namespace NationalInstruments.Analyzers.Correctness.StringsShouldBeInResources
         /// <param name="rootElement">
         /// Root node of an XML document containing exemptions for fields, string, files, assemblies, types, members, and namespaces.
         /// </param>
+        /// <param name="filePath">
+        /// Path to an XML file containing exemptions.
+        /// </param>
         protected override void LoadConfigurations(XElement rootElement, string filePath)
         {
             if (TryGetRootElementDiagnostic(rootElement, "Exemptions", filePath, StringsShouldBeInResourcesAnalyzer.FileParseRule, out var diagnostic))

--- a/src/NationalInstruments.Analyzers/GlobalSuppressions.cs
+++ b/src/NationalInstruments.Analyzers/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("MicrosoftCodeAnalysisCorrectness", "RS1026:Enable concurrent execution", Justification = "Concurrent execution _is_ enabled, conditionally")]

--- a/src/NationalInstruments.Analyzers/Style/DoNotUseLinqQuerySyntax/QueryComprehensionToFluentRewriter.cs
+++ b/src/NationalInstruments.Analyzers/Style/DoNotUseLinqQuerySyntax/QueryComprehensionToFluentRewriter.cs
@@ -609,7 +609,7 @@ namespace NationalInstruments.Tools.Analyzers.Style.DoNotUseLinqQuerySyntax
             var orderExpression = (ExpressionSyntax)SetFlagAndVisit(orderingSyntax.Expression);
 
             var orderByThenBy = firstOrderExpression ? "OrderBy" : "ThenBy";
-            orderByThenBy += orderingSyntax.AscendingOrDescendingKeyword.ValueText?.ToLower() == "descending"
+            orderByThenBy += orderingSyntax.AscendingOrDescendingKeyword.ValueText?.ToUpperInvariant() == "DESCENDING"
                                  ? "Descending"
                                  : string.Empty;
 

--- a/tests/NationalInstruments.Analyzers.TestUtilities.UnitTests/Assets/ExampleDiagnosticAnalyzer.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities.UnitTests/Assets/ExampleDiagnosticAnalyzer.cs
@@ -14,6 +14,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.UnitTests.Assets
     /// multiple arguments.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("MicrosoftCodeAnalysisReleaseTracking", "RS2008:Enable analyzer release tracking", Justification = "Used for testing")]
     public sealed class ExampleDiagnosticAnalyzer : NIDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "TEST1234";
@@ -46,6 +47,9 @@ namespace NationalInstruments.Analyzers.TestUtilities.UnitTests.Assets
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             // NoArgumentRule
             context.RegisterSyntaxNodeAction(AnalyzeConstructor, SyntaxKind.ConstructorDeclaration);
 

--- a/tests/NationalInstruments.Analyzers.TestUtilities/DefaultCodeFixProvider.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities/DefaultCodeFixProvider.cs
@@ -11,6 +11,11 @@ namespace NationalInstruments.Analyzers.TestUtilities
     {
         public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray<string>.Empty;
 
+        public override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             return Task.CompletedTask;

--- a/tests/NationalInstruments.Analyzers.UnitTests/ApprovedNamespaceAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/ApprovedNamespaceAnalyzerTests.cs
@@ -126,7 +126,8 @@ namespace <?>NationalInstruments.Designer
         {
         }
     }
-}", "NationalInstruments.Designer")]
+}",
+            "NationalInstruments.Designer")]
         [InlineData(
             @"
 namespace <?>Systematic.Windows
@@ -137,7 +138,8 @@ namespace <?>Systematic.Windows
         {
         }
     }
-}", "Systematic.Windows")]
+}",
+            "Systematic.Windows")]
         [InlineData(
             @"
 namespace <?>NotAQualifiedNamespace
@@ -148,7 +150,8 @@ namespace <?>NotAQualifiedNamespace
         {
         }
     }
-}", "NotAQualifiedNamespace")]
+}",
+            "NotAQualifiedNamespace")]
         [InlineData(
             @"
 namespace Systematic
@@ -162,7 +165,8 @@ namespace Systematic
             }
         }
     }
-}", "Systematic.Windows")]
+}",
+            "Systematic.Windows")]
         [InlineData(
             @"
 namespace NationalInstruments
@@ -185,7 +189,8 @@ namespace NationalInstruments
             }
         }
     }
-}", "NationalInstruments.Bogus")]
+}",
+            "NationalInstruments.Bogus")]
         [InlineData(
             @"
 namespace SomeNamespace
@@ -208,7 +213,8 @@ namespace SomeNamespace
             }
         }
     }
-}", "SomeNamespace.Tong")]
+}",
+            "SomeNamespace.Tong")]
         public void UnapprovedNamespace_Verify_EmitsDiagnostic(string sampleCode, string violatingNamespace)
         {
             using (var testState = new TestState())
@@ -313,7 +319,8 @@ namespace <?>NationalInstruments.Tests.Designer
         {
         }
     }
-}", "NationalInstruments.Tests.Designer")]
+}",
+            "NationalInstruments.Tests.Designer")]
         [InlineData(
             @"
 namespace <?>XUnity.Tests
@@ -324,7 +331,8 @@ namespace <?>XUnity.Tests
         {
         }
     }
-}", "XUnity.Tests")]
+}",
+            "XUnity.Tests")]
         public void UnapprovedTestNamespace_Verify_EmitsDiagnostic(string sampleCode, string violatingNamespace)
         {
             using (var testState = new TestState())
@@ -429,7 +437,8 @@ namespace <?>NationalInstruments.TestUtilities.Designer
         {
         }
     }
-}", "NationalInstruments.TestUtilities.Designer")]
+}",
+            "NationalInstruments.TestUtilities.Designer")]
         [InlineData(
             @"
 namespace <?>XUnity.TestUtilities.Core
@@ -440,7 +449,8 @@ namespace <?>XUnity.TestUtilities.Core
         {
         }
     }
-}", "XUnity.TestUtilities.Core")]
+}",
+            "XUnity.TestUtilities.Core")]
         public void UnapprovedTestUtilitiesNamespace_Verify_EmitsDiagnostic(string sampleCode, string violatingNamespace)
         {
             using (var testState = new TestState())

--- a/tests/NationalInstruments.Analyzers.UnitTests/ChainOfMethodsWithLambdasAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/ChainOfMethodsWithLambdasAnalyzerTests.cs
@@ -310,7 +310,8 @@ namespace NationalInstruments.Analyzers.UnitTests
         }
     }
 }
-",  GetNI1017Rule());
+",
+            GetNI1017Rule());
 
             VerifyDiagnostics(test);
         }
@@ -343,7 +344,8 @@ namespace NationalInstruments.Analyzers.UnitTests
         }
     }
 }
-", GetNI1017Rule());
+",
+            GetNI1017Rule());
 
             VerifyDiagnostics(test);
         }
@@ -429,7 +431,8 @@ namespace NationalInstruments.Analyzers.UnitTests
         }
     }
 }
-", GetNI1017Rule());
+",
+            GetNI1017Rule());
 
             VerifyDiagnostics(test);
         }
@@ -502,7 +505,8 @@ namespace NationalInstruments.Analyzers.UnitTests
             Predicate<string> predicate) => softwareContent;
     }
 }
-", GetNI1017Rule());
+",
+            GetNI1017Rule());
 
             VerifyDiagnostics(test);
         }
@@ -574,7 +578,8 @@ namespace NationalInstruments.Analyzers.UnitTests
         Creator Foo { get; }
     }
 }
-", GetNI1017Rule());
+",
+            GetNI1017Rule());
 
             VerifyDiagnostics(test);
         }
@@ -637,7 +642,8 @@ namespace NationalInstruments.Analyzers.UnitTests
         }
     }
 }
-", GetNI1017Rule());
+",
+            GetNI1017Rule());
 
             VerifyDiagnostics(test);
         }

--- a/tests/NationalInstruments.Analyzers.Utilities.UnitTests/AdditionalFileServiceTests.cs
+++ b/tests/NationalInstruments.Analyzers.Utilities.UnitTests/AdditionalFileServiceTests.cs
@@ -124,6 +124,9 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
 
             public override void Initialize(AnalysisContext context)
             {
+                context.EnableConcurrentExecution();
+                context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
                 context.RegisterCompilationStartAction(compilationStartContext =>
                 {
                     var additionalFileService = new AdditionalFileService(compilationStartContext.Options.AdditionalFiles, FileParseRule);


### PR DESCRIPTION
# Justification
Updating to the latest analyzers in #67 revealed some violations that can/should be solved in the current codebase first.

# Implementation
Solved most of the violations that the latest analyzers complained about. Those that remain require newer APIs.

# Testing
Ensured build/tests still pass.