### PR TITLE
Update C.1.1 to clarify company name should be NationalInstruments

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,8 @@ For information on when to create or not create a namespace, read [CSharp Coding
 
 ### [C.1.1] ✔️ **DO** Prefix namespace names with a company name to prevent namespaces from different companies from having the same name
 
+> :information_source: Note: For NI software, use "NationalInstruments" as the company name. Not "NI".
+
 ### [C.1.2] ✔️ **DO** Organize the hierarchy of namespaces around groups of related technologies
 
 ### [C.1.3] ✔️ **DO** Use PascalCasing and separate namespace components with periods


### PR DESCRIPTION
# Justification

For a new product namespace we had some discussion about whether we should be using "NI" or "NationalInstruments" after the company name change. There is already an analyzer rule that enforces using "NationalInstruments" so the choice is clear, but the conventions do not state this explicitly. This updates the README.md to clarify this case.

# Implementation

Update section C.1.1 concerning company names in namespaces

# Testing
N/A