### PR TITLE
Update dependencies in the nuget spec

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -62,7 +62,7 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
         <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.10.56" />
-        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" />
         <PackageReference Condition=" '$(IncludeCompatabilityAnalyzer)' == 'True' " Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/build/NI.CSharp.Analyzers.nuspec
+++ b/build/NI.CSharp.Analyzers.nuspec
@@ -15,15 +15,6 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="file">LICENSE.txt</license>
     <dependencies>
-      <group targetFramework="netstandard1.3">
-        <dependency id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.10" />
-        <dependency id="Microsoft.CodeQuality.Analyzers" version="2.9.10" />
-        <dependency id="Microsoft.NetCore.Analyzers" version="2.9.10" />
-        <dependency id="Microsoft.NetFramework.Analyzers" version="2.9.10" />
-        <dependency id="Microsoft.VisualStudio.Threading.Analyzers" version="16.3.52" />
-        <dependency id="Roslynator.Analyzers" version="2.1.0" />
-        <dependency id="StyleCop.Analyzers" version="1.1.118" />
-      </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.CodeAnalysis.CSharp" version="3.11.0" />
         <dependency id="Microsoft.CodeAnalysis.NetAnalyzers" version="5.0.3" />

--- a/build/NI.CSharp.Analyzers.nuspec
+++ b/build/NI.CSharp.Analyzers.nuspec
@@ -6,7 +6,7 @@
     <!--TODO: author and owner may have to change if we go to nuget.org -->
     <authors>NI</authors>
     <owners>NI</owners>
-    <copyright>Copyright 2020 National Instruments Corporation</copyright>
+    <copyright>Copyright 2022 National Instruments Corporation</copyright>
     <description>NI's code analyzers and rulesets for C# projects.</description>
     <summary>NI's code analyzers and rulesets for C# projects.</summary>
     <icon>images\icon.png</icon>
@@ -16,12 +16,12 @@
     <license type="file">LICENSE.txt</license>
     <dependencies>
       <group targetFramework="netstandard2.0">
-        <dependency id="Microsoft.CodeAnalysis.CSharp" version="3.11.0" />
         <dependency id="Microsoft.CodeAnalysis.NetAnalyzers" version="5.0.3" />
+        <dependency id="Microsoft.CodeAnalysis.CSharp" version="3.11.0" />
         <dependency id="Microsoft.CodeAnalysis.Analyzers" version="3.3.2" />
         <dependency id="Microsoft.VisualStudio.Threading.Analyzers" version="16.10.56" />
-        <dependency id="Roslynator.Analyzers" version="3.2.2" />
         <dependency id="StyleCop.Analyzers" version="1.2.0-beta.435" />
+        <dependency id="Roslynator.Analyzers" version="4.1.1" />
       </group>
     </dependencies>
   </metadata>

--- a/build/NI.CSharp.Analyzers.nuspec
+++ b/build/NI.CSharp.Analyzers.nuspec
@@ -24,6 +24,14 @@
         <dependency id="Roslynator.Analyzers" version="2.1.0" />
         <dependency id="StyleCop.Analyzers" version="1.1.118" />
       </group>
+      <group targetFramework="netstandard2.0">
+        <dependency id="Microsoft.CodeAnalysis.CSharp" version="3.11.0" />
+        <dependency id="Microsoft.CodeAnalysis.NetAnalyzers" version="5.0.3" />
+        <dependency id="Microsoft.CodeAnalysis.Analyzers" version="3.3.2" />
+        <dependency id="Microsoft.VisualStudio.Threading.Analyzers" version="16.10.56" />
+        <dependency id="Roslynator.Analyzers" version="3.2.2" />
+        <dependency id="StyleCop.Analyzers" version="1.2.0-beta.435" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <NILibraryTargetFramework>net5.0</NILibraryTargetFramework>
-    <NIAnalyzersTargetFramework>net461</NIAnalyzersTargetFramework>
+    <NIAnalyzersTargetFramework>net48</NIAnalyzersTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
# Justification
Continue the work in #67, it updated the build time dependencies but it did not update the dependencies in the nuget spec, which results in the nuget package still depends on the old dependencies.

# Implementation
- updated the dependencies (except Style Cop and Roslynator.Analyzers) in the nuspec to match the versions used in #67 
- updated StyleCop and Roslynator.Analyzers to latest.
- upgraded non-analyzer frameworks (for the tests only) from NET 4.6.1 to 4.8.0 (the latest GitHub windows build machine does not support 4.6.1 anymore)

# Testing
Ensured code builds and tests pass
