### PR TITLE
Remove 'true' from nuget push --no-symbols parameter

### DIFF
--- a/.github/workflows/automatic-publish.yml
+++ b/.github/workflows/automatic-publish.yml
@@ -59,6 +59,6 @@ jobs:
         run: dotnet pack .\src\NationalInstruments.Analyzers\NationalInstruments.Analyzers.csproj -p:NuspecFile=../../build/NI.CSharp.Analyzers.nuspec --no-build -p:NuspecProperties="Version=${{ steps.gitversion.outputs.nuGetVersionV2 }}"
 
       - name: Publish Nuget Package
-        run: dotnet nuget push .\.binaries\NationalInstruments.Analyzers\*.nupkg --skip-duplicate --no-symbols true --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push .\.binaries\NationalInstruments.Analyzers\*.nupkg --skip-duplicate --no-symbols --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
 
 

--- a/.github/workflows/manual-nuget-publish.yml
+++ b/.github/workflows/manual-nuget-publish.yml
@@ -56,4 +56,4 @@ jobs:
         run: dotnet pack .\src\NationalInstruments.Analyzers\NationalInstruments.Analyzers.csproj -p:NuspecFile=../../build/NI.CSharp.Analyzers.nuspec --no-build -p:NuspecProperties="Version=${{ steps.gitversion.outputs.nuGetVersionV2 }}"
 
       - name: Publish Nuget Package
-        run: dotnet nuget push .\.binaries\NationalInstruments.Analyzers\*.nupkg --skip-duplicate --no-symbols true --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push .\.binaries\NationalInstruments.Analyzers\*.nupkg --skip-duplicate --no-symbols --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
# Justification
We encountered error (same as https://github.com/NuGet/Home/issues/11601) while publishing the nuget.  The issue was introduced by .NET 6.

# Implementation
Remove true from --no-symbols as suggested

# Testing
N/A