### PR TITLE
Add new analyzer for Disposable derivations, with 4 tests

### DIFF
--- a/src/NationalInstruments.Analyzers.Utilities/Extensions/IMethodSymbolExtensions.cs
+++ b/src/NationalInstruments.Analyzers.Utilities/Extensions/IMethodSymbolExtensions.cs
@@ -1,0 +1,50 @@
+using Microsoft.CodeAnalysis;
+
+namespace NationalInstruments.Analyzers.Utilities.Extensions
+{
+    /// <summary>
+    /// Class that contains helpful extensions to <see cref="IMethodSymbol"/>.
+    /// </summary>
+    /// <remarks>
+    /// Microsoft has most of these extensions internally, but they haven't made them public.
+    /// </remarks>
+    public static class IMethodSymbolExtensions
+    {
+        /// <summary>
+        /// Checks if the given method is a Finalizer implementation.
+        /// </summary>
+        /// <param name="method">The method to check</param>
+        public static bool IsFinalizer(this IMethodSymbol method)
+        {
+            if (method.MethodKind == MethodKind.Destructor)
+            {
+                return true; // for C#
+            }
+
+            if (method.Name != WellKnownMemberNames.DestructorName || !method.Parameters.IsEmpty || !method.ReturnsVoid)
+            {
+                return false;
+            }
+
+            IMethodSymbol overridden = method.OverriddenMethod;
+
+            if (method.ContainingType.SpecialType == SpecialType.System_Object)
+            {
+                // This is object.Finalize
+                return true;
+            }
+
+            if (overridden == null)
+            {
+                return false;
+            }
+
+            for (IMethodSymbol o = overridden.OverriddenMethod; o != null; o = o.OverriddenMethod)
+            {
+                overridden = o;
+            }
+
+            return overridden.ContainingType.SpecialType == SpecialType.System_Object; // it is object.Finalize
+        }
+    }
+}

--- a/src/NationalInstruments.Analyzers.Utilities/Extensions/IMethodSymbolExtensions.cs
+++ b/src/NationalInstruments.Analyzers.Utilities/Extensions/IMethodSymbolExtensions.cs
@@ -12,6 +12,7 @@ namespace NationalInstruments.Analyzers.Utilities.Extensions
     {
         /// <summary>
         /// Checks if the given method is a Finalizer implementation.
+        /// https://github.com/dotnet/roslyn-analyzers/blob/846a766f73caa82608db6fee9f2860004298449f/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs#L114
         /// </summary>
         /// <param name="method">The method to check</param>
         public static bool IsFinalizer(this IMethodSymbol method)

--- a/src/NationalInstruments.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/NationalInstruments.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,2 +1,7 @@
 ﻿; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+NI1816X | NationalInstruments | Warning | DisposableOmitsFinalizerAnalyzer

--- a/src/NationalInstruments.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/NationalInstruments.Analyzers/AnalyzerReleases.Unshipped.md
@@ -4,4 +4,4 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-NI1816X | NationalInstruments | Warning | DisposableOmitsFinalizerAnalyzer
+NI1816X | NationalInstruments | Disabled | DisposableOmitsFinalizerAnalyzer

--- a/src/NationalInstruments.Analyzers/Correctness/DisposableOmitsFinalizerAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/DisposableOmitsFinalizerAnalyzer.cs
@@ -19,7 +19,7 @@ namespace NationalInstruments.Analyzers.Correctness
             new LocalizableResourceString(nameof(Resources.NI1816X_MessageFormat), Resources.ResourceManager, typeof(Resources)),
             category: "NationalInstruments",
             DiagnosticSeverity.Warning,
-            isEnabledByDefault: true,
+            isEnabledByDefault: false,
             description: new LocalizableResourceString(nameof(Resources.NI1816X_Description), Resources.ResourceManager, typeof(Resources)));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);

--- a/src/NationalInstruments.Analyzers/Correctness/DisposableOmitsFinalizerAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/DisposableOmitsFinalizerAnalyzer.cs
@@ -1,0 +1,51 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NationalInstruments.Analyzers.Properties;
+using NationalInstruments.Analyzers.Utilities;
+using NationalInstruments.Analyzers.Utilities.Extensions;
+
+namespace NationalInstruments.Analyzers.Correctness
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class DisposableOmitsFinalizerAnalyzer : NIDiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "NI1816X";
+
+        public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            new LocalizableResourceString(nameof(Resources.NI1816X_Title), Resources.ResourceManager, typeof(Resources)),
+            new LocalizableResourceString(nameof(Resources.NI1816X_MessageFormat), Resources.ResourceManager, typeof(Resources)),
+            category: "NationalInstruments",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: new LocalizableResourceString(nameof(Resources.NI1816X_Description), Resources.ResourceManager, typeof(Resources)));
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+        }
+
+        private static void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+
+            if (namedTypeSymbol.IsOrInheritsFromClass("NationalInstruments.Core.Disposable"))
+            {
+                if (namedTypeSymbol.GetMembers()
+                    .OfType<IMethodSymbol>()
+                    .Any(m => m.IsFinalizer()))
+                {
+                    // For all such symbols, produce a diagnostic.
+                    var diagnostic = Diagnostic.Create(Rule, namedTypeSymbol.Locations[0], namedTypeSymbol.Name);
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+        }
+    }
+}

--- a/src/NationalInstruments.Analyzers/Correctness/DisposableOmitsFinalizerAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/DisposableOmitsFinalizerAnalyzer.cs
@@ -27,7 +27,7 @@ namespace NationalInstruments.Analyzers.Correctness
         public override void Initialize(AnalysisContext context)
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-            context.EnableConcurrentExecution();
+            context.EnableConcurrentExecutionIf(IsRunningInProduction);
             context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
         }
 

--- a/src/NationalInstruments.Analyzers/Properties/Resources.Designer.cs
+++ b/src/NationalInstruments.Analyzers/Properties/Resources.Designer.cs
@@ -754,6 +754,33 @@ namespace NationalInstruments.Analyzers.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Type derived from Disposable must not contain a finalizer..
+        /// </summary>
+        internal static string NI1816X_Description {
+            get {
+                return ResourceManager.GetString("NI1816X_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Type name {0} must remove its finalizer.
+        /// </summary>
+        internal static string NI1816X_MessageFormat {
+            get {
+                return ResourceManager.GetString("NI1816X_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Disposable should not have finalizer.
+        /// </summary>
+        internal static string NI1816X_Title {
+            get {
+                return ResourceManager.GetString("NI1816X_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0}.
         /// </summary>
         internal static string ParseError_Message {

--- a/src/NationalInstruments.Analyzers/Properties/Resources.resx
+++ b/src/NationalInstruments.Analyzers/Properties/Resources.resx
@@ -405,4 +405,13 @@
     <value>Missing namespace approval files</value>
     <comment>The title of the diagnostic.</comment>
   </data>
+  <data name="NI1816X_Description" xml:space="preserve">
+    <value>Type derived from Disposable must not contain a finalizer.</value>
+  </data>
+  <data name="NI1816X_MessageFormat" xml:space="preserve">
+    <value>Type name {0} must remove its finalizer</value>
+  </data>
+  <data name="NI1816X_Title" xml:space="preserve">
+    <value>Disposable should not have finalizer</value>
+  </data>
 </root>

--- a/tests/NationalInstruments.Analyzers.UnitTests/DisposableOmitsFinalizerAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/DisposableOmitsFinalizerAnalyzerTests.cs
@@ -1,0 +1,100 @@
+using System.Data.Common;
+using NationalInstruments.Analyzers.Correctness;
+using NationalInstruments.Analyzers.TestUtilities;
+using NationalInstruments.Analyzers.TestUtilities.TestFiles;
+using NationalInstruments.Analyzers.TestUtilities.Verifiers;
+using Xunit;
+
+namespace NationalInstruments.Analyzers.UnitTests
+{
+    /// <summary>
+    /// Tests that <see cref="DisposableOmitsFinalizerAnalyzer" /> emits a violation when necessary.
+    /// </summary>
+    public sealed class DisposableOmitsFinalizerAnalyzerTests : NIDiagnosticAnalyzerTests<DisposableOmitsFinalizerAnalyzer>
+    {
+        [Fact]
+        public void NI1816X_ClassNotDerivedHasFinalizer_NoDiagnostic()
+        {
+            var goodCode = @"
+    using System;
+    namespace NationalInstruments.Core
+    {
+        internal class NonDerivedDisposable : IDisposable
+        {
+            public NonDerivedDisposable()
+            {
+            }
+            ~NonDerivedDisposable()
+            {
+            }
+            public void Dispose()
+            {
+            }
+        }
+    }";
+
+            var test = new TestFile(goodCode);
+            VerifyDiagnostics(test);
+        }
+
+        [Fact]
+        public void NI1816X_ClassDerivedOmitsFinalizer_NoDiagnostic()
+        {
+            var goodCode = @"
+    using System;
+    namespace NationalInstruments.Core
+    {
+        internal class Disposable : IDisposable
+        {
+            public Disposable()
+            {
+            }
+            public void Dispose()
+            {
+            }
+        }
+        internal class DerivedDisposable : Disposable
+        {   
+            public DerivedDisposable()
+            {
+            }
+        }
+    }";
+
+            var test = new TestFile(goodCode);
+            VerifyDiagnostics(test);
+        }
+
+        [Fact]
+        public void NI1816X_ClassDerivedHasFinalizer_HasDiagnostic()
+        {
+            var badCode = @"
+    using System;
+    namespace NationalInstruments.Core
+    {
+        internal class Disposable : IDisposable
+        {
+            public Disposable()
+            {
+            }
+            public void Dispose()
+            {
+            }
+        }
+        internal class DerivedDisposable : Disposable
+        {   
+            public DerivedDisposable()
+            {
+            }
+            ~DerivedDisposable()
+            {
+            }
+        }
+    }";
+
+            var test = new TestFile(badCode);
+            var expectedFailure = GetResultAt(14, 24, DisposableOmitsFinalizerAnalyzer.Rule, "DerivedDisposable");
+            VerifyDiagnostics(test, expectedFailure);
+        }
+    }
+}


### PR DESCRIPTION
# Justification
For the `Disposable` base class, we want to avoid calling `GC.SuppressFinalize` and we need to ensure it's safe to do so. The way to do that is to prevent derivations from having a finalizer.

See the [conversation on my ASW PR](https://dev.azure.com/ni/DevCentral/_git/ASW/pullrequest/373013?_a=files&path=%2FSource%2FCore%2FCore%2FCore%2FDisposable.cs&discussionId=3675859).

# Implementation
Implement an analyzer that creates a diagnostic when a class derived from Disposable has a finalizer.

# Testing
`DisposableOmitsFinalizerAnalyzerTests` includes success and failure test cases.