### PR TITLE
Fix issue 77 and add tests

### DIFF
--- a/src/NationalInstruments.Analyzers/Style/FieldsCamelCasedWithUnderscoreCodeFixProvider.cs
+++ b/src/NationalInstruments.Analyzers/Style/FieldsCamelCasedWithUnderscoreCodeFixProvider.cs
@@ -106,7 +106,7 @@ namespace NationalInstruments.Analyzers.Style
             var suffix = 2;
             var name = baseName;
 
-            while (!symbols.Any(x => string.Equals(x.Name, name, StringComparison.Ordinal)))
+            while (symbols.Any(x => string.Equals(x.Name, name, StringComparison.Ordinal)))
             {
                 name = baseName + suffix.ToString(CultureInfo.InvariantCulture);
                 suffix++;

--- a/tests/NationalInstruments.Analyzers.UnitTests/FieldsCamelCasedWithUnderscoreAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/FieldsCamelCasedWithUnderscoreAnalyzerTests.cs
@@ -224,7 +224,7 @@ class Foo
             VerifyDiagnostics(test);
         }
 
-        private Rule GetNI1001FieldsCamelCasedWithUnderscoreRule() 
+        private Rule GetNI1001FieldsCamelCasedWithUnderscoreRule()
             => new Rule(FieldsCamelCasedWithUnderscoreAnalyzer.Rule);
     }
 }


### PR DESCRIPTION
# Justification
@davkean identified a performance issue with FieldsCamelCasedWithUnderscoreCodeFixProvider.

# Implementation
@mavasani determined we were matching symbols that **didn't** match the invalid name when in reality we wanted the reverse.

# Testing
Added code fixer tests. Confirmed these failed to complete (in a reasonable time) with the old code and pass instantly with the new.