### PR TITLE
Update net analyzer version

### DIFF
--- a/build/NI.CSharp.Analyzers.nuspec
+++ b/build/NI.CSharp.Analyzers.nuspec
@@ -21,7 +21,7 @@
         <dependency id="Microsoft.CodeAnalysis.Analyzers" version="3.3.3" />
         <dependency id="Microsoft.VisualStudio.Threading.Analyzers" version="17.2.32" />
         <dependency id="StyleCop.Analyzers" version="1.2.0-beta.435" />
-        <dependency id="Roslynator.Analyzers" version="4.3.0" />
+        <dependency id="Roslynator.Analyzers" version="4.1.1" />
       </group>
     </dependencies>
   </metadata>

--- a/build/NI.CSharp.Analyzers.nuspec
+++ b/build/NI.CSharp.Analyzers.nuspec
@@ -6,7 +6,7 @@
     <!--TODO: author and owner may have to change if we go to nuget.org -->
     <authors>NI</authors>
     <owners>NI</owners>
-    <copyright>Copyright 2022 National Instruments Corporation</copyright>
+    <copyright>Copyright 2023 National Instruments Corporation</copyright>
     <description>NI's code analyzers and rulesets for C# projects.</description>
     <summary>NI's code analyzers and rulesets for C# projects.</summary>
     <icon>images\icon.png</icon>
@@ -16,12 +16,12 @@
     <license type="file">LICENSE.txt</license>
     <dependencies>
       <group targetFramework="netstandard2.0">
-        <dependency id="Microsoft.CodeAnalysis.NetAnalyzers" version="6.0.0" />
+        <dependency id="Microsoft.CodeAnalysis.NetAnalyzers" version="7.0.4" />
         <dependency id="Microsoft.CodeAnalysis.CSharp" version="4.2.0" />
         <dependency id="Microsoft.CodeAnalysis.Analyzers" version="3.3.3" />
         <dependency id="Microsoft.VisualStudio.Threading.Analyzers" version="17.2.32" />
         <dependency id="StyleCop.Analyzers" version="1.2.0-beta.435" />
-        <dependency id="Roslynator.Analyzers" version="4.1.1" />
+        <dependency id="Roslynator.Analyzers" version="4.3.0" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
# Justification
The current latest stable .NET analyzer is 7.0.4, we should upgrade our dependency so consumers of our nuget package can get the latest analysis rules.

The list of rules that the .NET analyzer checks depends on [`<AnalysisLevel>`](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#analysislevel).  By default, `<AnalysisLevel>` is set to "latest", but that means *latest that your current SDK supports*.  Thus for projects building in .NET 6, the default `<AnalysisLevel>` is 6.0, even if there is a newer level available from the nuget package.

At the same time, it is possible for .NET 6 project to specify `<AnalysisLevel>7.0</AnalysisLevel>` to get the .NET 7 code analysis rules without upgrading to .NET 7 SDK—this allows consumers to take advantage of newer code analysis rules sooner.

# Implementation
- Update `Microsoft.CodeAnalysis.NetAnalyzers` to `7.0.4`.

# Testing

Built a nuget package locally and updated ASW to use the local nuget.  After setting `<AnalysisLevel>7.0</AnalysisLevel>`, I started to get new warnings.