### PR TITLE
Introduce new analysis mode

### DIFF
--- a/src/AnalyzerConfiguration/NI.CSharp.Analyzers.TestUtilities.globalconfig
+++ b/src/AnalyzerConfiguration/NI.CSharp.Analyzers.TestUtilities.globalconfig
@@ -2,7 +2,7 @@
 is_global = true
 
 # set global level higher than NI.CSharp.Analyzers.globalconfig to override rules specified below
-global_level = 1
+global_level = -97
 
 # NI.TestUtilities.ruleset
 # Description: Code analysis rule overrides for NI Test Utility projects.

--- a/src/AnalyzerConfiguration/NI.CSharp.Analyzers.Tests.globalconfig
+++ b/src/AnalyzerConfiguration/NI.CSharp.Analyzers.Tests.globalconfig
@@ -2,7 +2,7 @@
 is_global = true
 
 # set global level higher than NI.CSharp.Analyzers.globalconfig to override rules specified below
-global_level = 1
+global_level = -97
 
 # NI.Tests.ruleset
 # Description: Code analysis rule overrides for NI Test projects.

--- a/src/AnalyzerConfiguration/NI.CSharp.Analyzers.globalconfig
+++ b/src/AnalyzerConfiguration/NI.CSharp.Analyzers.globalconfig
@@ -1,6 +1,10 @@
 # NOTE: Requires **VS2019 16.7** or later
 is_global = true
-global_level = 0
+
+# The .NET global config for different AnalysisMode categories (e.g. Usage, Performance, Design, etc)
+# have global level set at -99, and we want to be a higher level so that we can override the configured
+# warnings.
+global_level = -98
 
 # NI.ruleset
 # Description: Code analysis rules for NI projects.
@@ -147,6 +151,12 @@ dotnet_diagnostic.CA1505.severity = none
 dotnet_diagnostic.CA1506.severity = none
 
 dotnet_diagnostic.CA1507.severity = none
+
+# CA1508: Avoid dead conditional code
+#   While useful, this rule has a buggy implementation and has too many
+#   false positives, particularly when analyzing code inside loops and
+#   try-finally code.
+dotnet_diagnostic.CA1508.severity = none
 
 dotnet_diagnostic.CA1601.severity = warning
 

--- a/src/AnalyzerConfiguration/NI.CSharp.Analyzers.props
+++ b/src/AnalyzerConfiguration/NI.CSharp.Analyzers.props
@@ -9,6 +9,9 @@
     <NI_IsTestUtilitiesProject Condition="'$(NI_IsTestUtilitiesProject)' != 'True'">$(MSBuildProjectName.StartsWith("!TestUtilities."))</NI_IsTestUtilitiesProject>
     <!-- The following is needed for misnamed TestUtilities that contain xaml because the generated project for the second compile appends random characters to the end of the project name -->
     <NI_IsTestUtilitiesProject Condition="'$(NI_IsTestUtilitiesProject)' != 'True' and '$(NI_IsTestProject)' != 'True'">$(MSBuildProjectName.Contains(".TestUtilities"))</NI_IsTestUtilitiesProject>
+
+    <AnalysisMode Condition="'$(AnalysisMode)' == ''">NI</AnalysisMode>
+    <AnalysisLevel>7.0</AnalysisLevel>
   </PropertyGroup>
 
   <!-- 
@@ -23,7 +26,7 @@
     EditorConfigFiles is what is passed to the compile target, not GlobalAnalyzerConfigFiles.  Because our targets file may be imported *after*
     the Microsoft code analyzer targets file, by the time we update GlobalAnalyzerConfigFiles it will be too late.
   -->
-  <ItemGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '6.0'))">
+  <ItemGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '6.0')) and '$(AnalysisMode)' == 'NI'">
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)../content/NI.CSharp.Analyzers.globalconfig" />
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)../content/NI.CSharp.Analyzers.Tests.globalconfig" Condition="'$(NI_IsTestProject)' == 'True'" />
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)../content/NI.CSharp.Analyzers.TestUtilities.globalconfig" Condition="'$(NI_IsTestUtilitiesProject)' == 'True'" />

--- a/src/AnalyzerConfiguration/NI.CSharp.Analyzers.props
+++ b/src/AnalyzerConfiguration/NI.CSharp.Analyzers.props
@@ -10,7 +10,26 @@
     <!-- The following is needed for misnamed TestUtilities that contain xaml because the generated project for the second compile appends random characters to the end of the project name -->
     <NI_IsTestUtilitiesProject Condition="'$(NI_IsTestUtilitiesProject)' != 'True' and '$(NI_IsTestProject)' != 'True'">$(MSBuildProjectName.Contains(".TestUtilities"))</NI_IsTestUtilitiesProject>
 
+    <!--
+      Microsoft supports analysis modes that preconfigure code analysis rules (e.g. All, Recommended, Minimum, etc).
+      We will introduce a new analysis mode "NI" that represents the set of rules that we enable/disable.
+
+      While Microsoft's analysis modes come with a dedicated global config that lists all CA rule specifications, 
+      we currently construct the rules by setting per category warnings to all and then adding NI.CSharp.Analyzers.globalconfig
+      that selectively overrides the warnings we want to disable.  This is done for maintenance reasons: we do not need to update
+      the complete list of CA rules every year, we just need to maintain the rules we want to disable.
+
+      The drawback to the approach is if individual projects want to configure a different per-category setting (i.e. 
+      use NI mode but set Performance category to "Minimum"), it may not work if NI.CSharp.Analyzers.globalconfig has a
+      conflicting rule.
+      
+      NI.CSharp.Analyzers.globalconfig has a higher global level than the per-category global config precisely
+      to allow overriding of rules.  But if the per-category rules is preferred by the project, it may end up getting
+      overriden by NI.CSharp.Analyzers.globalconfig.  The workaround is to copy the per-category global config to a
+      new file that is included by the project and set the global level to higher than NI.CSharp.Analyzers.globalconfig.
+    -->
     <AnalysisMode Condition="'$(AnalysisMode)' == ''">NI</AnalysisMode>
+
     <AnalysisLevel>7.0</AnalysisLevel>
   </PropertyGroup>
 

--- a/src/AnalyzerConfiguration/NI.CSharp.Analyzers.targets
+++ b/src/AnalyzerConfiguration/NI.CSharp.Analyzers.targets
@@ -10,6 +10,22 @@
     <CodeAnalysisRuleSetDefined Condition="'$(CodeAnalysisRuleSet)' != '' and '$(CodeAnalysisRuleSet)' != 'MinimumRecommendedRules.ruleset'">True</CodeAnalysisRuleSetDefined>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(AnalysisMode)' == 'NI'">
+    <AnalysisModeStyle Condition="'$(AnalysisModeStyle)' == ''">Default</AnalysisModeStyle>
+    <AnalysisModeSecurity Condition="'$(AnalysisModeSecurity)' == ''">Default</AnalysisModeSecurity>
+    <AnalysisModeDesign Condition="'$(AnalysisModeDesign)' == ''">All</AnalysisModeDesign>
+    <AnalysisModeDocumentation Condition="'$(AnalysisModeDocumentation)' == ''">All</AnalysisModeDocumentation>
+    <AnalysisModeGlobalization Condition="'$(AnalysisModeGlobalization)' == ''">All</AnalysisModeGlobalization>
+    <AnalysisModeInteroperability Condition="'$(AnalysisModeInteroperability)' == ''">All</AnalysisModeInteroperability>
+    <AnalysisModeMaintainability Condition="'$(AnalysisModeMaintainability)' == ''">All</AnalysisModeMaintainability>
+    <AnalysisModeNaming Condition="'$(AnalysisModeNaming)' == ''">All</AnalysisModeNaming>
+    <AnalysisModePerformance Condition="'$(AnalysisModePerformance)' == ''">All</AnalysisModePerformance>
+    <AnalysisModeReliability Condition="'$(AnalysisModeReliability)' == ''">All</AnalysisModeReliability>
+    <AnalysisModeUsage Condition="'$(AnalysisModeUsage)' == ''">All</AnalysisModeUsage>
+
+    <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(CodeAnalysisRuleSetDefined)' == 'False'">
     <CodeAnalysisRuleSet>$(NI_CodeAnalysisRuleSetDirectory)\NI.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSet Condition="'$(NI_IsTestUtilitiesProject)' == 'True'">$(NI_CodeAnalysisRuleSetDirectory)\NI.TestUtilities.ruleset</CodeAnalysisRuleSet>

--- a/src/AnalyzerConfiguration/NI.CSharp.Analyzers.targets
+++ b/src/AnalyzerConfiguration/NI.CSharp.Analyzers.targets
@@ -10,22 +10,6 @@
     <CodeAnalysisRuleSetDefined Condition="'$(CodeAnalysisRuleSet)' != '' and '$(CodeAnalysisRuleSet)' != 'MinimumRecommendedRules.ruleset'">True</CodeAnalysisRuleSetDefined>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(AnalysisMode)' == 'NI'">
-    <AnalysisModeStyle Condition="'$(AnalysisModeStyle)' == ''">Default</AnalysisModeStyle>
-    <AnalysisModeSecurity Condition="'$(AnalysisModeSecurity)' == ''">Default</AnalysisModeSecurity>
-    <AnalysisModeDesign Condition="'$(AnalysisModeDesign)' == ''">All</AnalysisModeDesign>
-    <AnalysisModeDocumentation Condition="'$(AnalysisModeDocumentation)' == ''">All</AnalysisModeDocumentation>
-    <AnalysisModeGlobalization Condition="'$(AnalysisModeGlobalization)' == ''">All</AnalysisModeGlobalization>
-    <AnalysisModeInteroperability Condition="'$(AnalysisModeInteroperability)' == ''">All</AnalysisModeInteroperability>
-    <AnalysisModeMaintainability Condition="'$(AnalysisModeMaintainability)' == ''">All</AnalysisModeMaintainability>
-    <AnalysisModeNaming Condition="'$(AnalysisModeNaming)' == ''">All</AnalysisModeNaming>
-    <AnalysisModePerformance Condition="'$(AnalysisModePerformance)' == ''">All</AnalysisModePerformance>
-    <AnalysisModeReliability Condition="'$(AnalysisModeReliability)' == ''">All</AnalysisModeReliability>
-    <AnalysisModeUsage Condition="'$(AnalysisModeUsage)' == ''">All</AnalysisModeUsage>
-
-    <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">true</EnforceCodeStyleInBuild>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(CodeAnalysisRuleSetDefined)' == 'False'">
     <CodeAnalysisRuleSet>$(NI_CodeAnalysisRuleSetDirectory)\NI.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSet Condition="'$(NI_IsTestUtilitiesProject)' == 'True'">$(NI_CodeAnalysisRuleSetDirectory)\NI.TestUtilities.ruleset</CodeAnalysisRuleSet>
@@ -40,6 +24,22 @@
   <PropertyGroup>
     <!--AdditionalSpellingDictionary.dic contains the differences in words between the hunspell and Microsoft dictionaries-->
     <NI1704_AdditionalSpellingDictionary>$(NI_CodeAnalysisRuleSetDirectory)\NI1704_AdditionalSpellingDictionary.dic</NI1704_AdditionalSpellingDictionary>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(NI_EnableAnalyzers)' == 'True' and '$(AnalysisMode)' == 'NI'">
+    <AnalysisModeStyle Condition="'$(AnalysisModeStyle)' == ''">Default</AnalysisModeStyle>
+    <AnalysisModeSecurity Condition="'$(AnalysisModeSecurity)' == ''">Default</AnalysisModeSecurity>
+    <AnalysisModeDesign Condition="'$(AnalysisModeDesign)' == ''">All</AnalysisModeDesign>
+    <AnalysisModeDocumentation Condition="'$(AnalysisModeDocumentation)' == ''">All</AnalysisModeDocumentation>
+    <AnalysisModeGlobalization Condition="'$(AnalysisModeGlobalization)' == ''">All</AnalysisModeGlobalization>
+    <AnalysisModeInteroperability Condition="'$(AnalysisModeInteroperability)' == ''">All</AnalysisModeInteroperability>
+    <AnalysisModeMaintainability Condition="'$(AnalysisModeMaintainability)' == ''">All</AnalysisModeMaintainability>
+    <AnalysisModeNaming Condition="'$(AnalysisModeNaming)' == ''">All</AnalysisModeNaming>
+    <AnalysisModePerformance Condition="'$(AnalysisModePerformance)' == ''">All</AnalysisModePerformance>
+    <AnalysisModeReliability Condition="'$(AnalysisModeReliability)' == ''">All</AnalysisModeReliability>
+    <AnalysisModeUsage Condition="'$(AnalysisModeUsage)' == ''">All</AnalysisModeUsage>
+
+    <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(NI_EnableAnalyzers)' == 'True'">


### PR DESCRIPTION
# Justification
Microsoft supports analysis modes that preconfigure code analysis rules (e.g. All, Recommended, Minimum, etc).  Projects can set `<AnalysisMode>` to the preconfigured rulesets to enable/disable different warnings.

While we currently have our own rule specifications, we rely on setting `<AnalysisMode>` to `All` and using a global config file to selectively disable certain rules.  As a result, consumers of our nuget cannot specify a different `<AnalysisMode>`, because our global config is currently applied unconditionally and may override certain rules.

To solve this, we should introduce a new analysis mode "NI" that represents the set of rules that we enable/disable.  Our `props/targets` files will look for the NI analysis mode to decide whether to include our override global config.  If the project elects to use their own `<AnalysisMode>`, then the override global config is NOT included and the project gets the right rules configurations.

# Implementation
- Update `props` file to set `AnalysisMode` to `NI` if not already set.
- Update `props` file to include `NI.CSharp.Analyzers.globalconfig` only if `AnalysisMode` is `NI`.
- Update `targets` file to set per-category `AnalysisMode` only if `AnalysisMode` is `NI` to enable the rulesets we want for each category.
- Additional updated the global config file's global level to -98 to be consistent with Microsoft's global config files.

# Testing
Built nuget file and used ASW to test.  Made sure a private unsealed class generated CA 1852 correctly, and verified in binlog viewer that the global config files are correctly excluded when explicitly setting `<AnalysisMode>None</AnalysisMode>`