### PR TITLE
Only set AnalysisLevel if unset

### DIFF
--- a/src/AnalyzerConfiguration/NI.CSharp.Analyzers.props
+++ b/src/AnalyzerConfiguration/NI.CSharp.Analyzers.props
@@ -30,7 +30,7 @@
     -->
     <AnalysisMode Condition="'$(AnalysisMode)' == ''">NI</AnalysisMode>
 
-    <AnalysisLevel>7.0</AnalysisLevel>
+    <AnalysisLevel Condition="'$(AnalysisLevel)' == ''">7.0</AnalysisLevel>
   </PropertyGroup>
 
   <!-- 


### PR DESCRIPTION
# Justification
Our props file currently unconditionally sets `<AnalysisLevel>` to `7,0`.  However, the nuget props files are imported *after* `Directory.Build.props`;  if a project explicitly sets `<AnalysisLevel>` using `Directory.Build.props`, our props file will incorrectly overwrite that setting.

# Implementation
Set the analysis level only if it is unset.

# Testing

I discovered this issue when upgrading ASW to use the latest NI analyzer nuget.  There was code that explicitly set `<AnalysisLevel>` to `4` in `Directory.Build.props` that started to emit .NET 5 warnings. 

After making the change locally in the props file, the build succeeds without warnings.