### PR TITLE
Make sure '$(NETCoreSdkVersion)' is not empty before comparing.

### DIFF
--- a/src/AnalyzerConfiguration/NI.CSharp.Analyzers.props
+++ b/src/AnalyzerConfiguration/NI.CSharp.Analyzers.props
@@ -45,7 +45,7 @@
     EditorConfigFiles is what is passed to the compile target, not GlobalAnalyzerConfigFiles.  Because our targets file may be imported *after*
     the Microsoft code analyzer targets file, by the time we update GlobalAnalyzerConfigFiles it will be too late.
   -->
-  <ItemGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '6.0')) and '$(AnalysisMode)' == 'NI'">
+  <ItemGroup Condition="'$(NETCoreSdkVersion)' != '' and $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '6.0')) and '$(AnalysisMode)' == 'NI'">
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)../content/NI.CSharp.Analyzers.globalconfig" />
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)../content/NI.CSharp.Analyzers.Tests.globalconfig" Condition="'$(NI_IsTestProject)' == 'True'" />
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)../content/NI.CSharp.Analyzers.TestUtilities.globalconfig" Condition="'$(NI_IsTestUtilitiesProject)' == 'True'" />


### PR DESCRIPTION
# Justification

I added `<GlobalPackageReference Include="NI.CSharp.Analyzers" Version="2.0.14" />` in `Directory.Packages.props` file. But we have both SDK-style and non-SDK style C# projects in our repo, I met below issue when I load and build non-SDK style projects in Visual Studio 2022.
![image](https://github.com/ni/csharp-styleguide/assets/108907860/ca36d79e-631d-4446-88b9-895a96f15b3c)

Detail information see this [thread](https://teams.microsoft.com/l/message/19:fa6c03f513634f62bf6cd34f671d918e@thread.tacv2/1701659441309?tenantId=87ba1f9a-44cd-43a6-b008-6fdb45a5204e&groupId=aafb5b0d-568c-48cb-9363-5a95158412ab&parentMessageId=1701659441309&teamName=Software%20Discussion&channelName=C%E2%99%AF%20and%20.NET&createdTime=1701659441309).

# Implementation
Make sure '$(NETCoreSdkVersion)' is not empty before comparing.

# Testing
this issuse has been resolved after I manually edit this file in my dev pc.