### PR TITLE
Update to use the 8.0.0 analyzer

### DIFF
--- a/build/NI.CSharp.Analyzers.nuspec
+++ b/build/NI.CSharp.Analyzers.nuspec
@@ -16,6 +16,11 @@
     <license type="file">LICENSE.txt</license>
     <dependencies>
       <group targetFramework="netstandard2.0">
+        <!-- 
+          IMPORTANT: when updating Microsoft.CodeAnalysis.NetAnalayzers to a new
+          major version, make sure to update AnalysisLevel in NI.CSharp.Analysers.props
+          too, otherwise new rules will not be properly enabled.
+        -->
         <dependency id="Microsoft.CodeAnalysis.NetAnalyzers" version="8.0.0" />
         <dependency id="Microsoft.CodeAnalysis.CSharp" version="4.2.0" />
         <dependency id="Microsoft.CodeAnalysis.Analyzers" version="3.3.3" />

--- a/build/NI.CSharp.Analyzers.nuspec
+++ b/build/NI.CSharp.Analyzers.nuspec
@@ -16,7 +16,7 @@
     <license type="file">LICENSE.txt</license>
     <dependencies>
       <group targetFramework="netstandard2.0">
-        <dependency id="Microsoft.CodeAnalysis.NetAnalyzers" version="7.0.4" />
+        <dependency id="Microsoft.CodeAnalysis.NetAnalyzers" version="8.0.0" />
         <dependency id="Microsoft.CodeAnalysis.CSharp" version="4.2.0" />
         <dependency id="Microsoft.CodeAnalysis.Analyzers" version="3.3.3" />
         <dependency id="Microsoft.VisualStudio.Threading.Analyzers" version="17.2.32" />

--- a/src/AnalyzerConfiguration/NI.CSharp.Analyzers.props
+++ b/src/AnalyzerConfiguration/NI.CSharp.Analyzers.props
@@ -30,7 +30,13 @@
     -->
     <AnalysisMode Condition="'$(AnalysisMode)' == ''">NI</AnalysisMode>
 
-    <AnalysisLevel Condition="'$(AnalysisLevel)' == ''">7.0</AnalysisLevel>
+    <!--
+      If AnalysisLevel is not set, the .NET SDK will default to the version of the SDK.  If the SDK is less than .NET 8,
+      then despite having a .NET 8 analyzer nuget referenced, we will use the lower SDK version as the analysis level.
+
+      Thus we manually set the default analysis level to 8.0 to make sure .NET 8 warnings are still checked.
+    -->
+    <AnalysisLevel Condition="'$(AnalysisLevel)' == ''">8.0</AnalysisLevel>
   </PropertyGroup>
 
   <!-- 


### PR DESCRIPTION
# Justification
With .NET 8 released, the Microsoft Net Analyzer also has a new 8.0.0 analyzer available.  We should update our NI analyzer to use the new 8.0.0 analyzer so that consuming projects can check .NET 8 warnings.

# Implementation
- Update the analyzer version to 8.0.0.
- Update the default analysis level to 8.0 to enable .NET 8 warning checking.

# Testing
Built the nuget locally and tested with building ASW.  Verified in the binlog that compilation is now using the 8.0.0 analyzer:

![image](https://github.com/ni/csharp-styleguide/assets/1291962/e1794a20-bc83-4328-bb57-b31fd1b2f5cd)

![image](https://github.com/ni/csharp-styleguide/assets/1291962/43303d4e-3bac-4ff7-a4f9-e430eb59a48e)
