### PR TITLE
Enable nullable and correct usages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,9 @@
         <NILibraryTargetFramework>net6.0</NILibraryTargetFramework>
         <NIExecutableTargetFramework>net6.0</NIExecutableTargetFramework>
         <NIAnalyzersTargetFramework>netstandard2.0</NIAnalyzersTargetFramework>
+
+        <Nullable>enable</Nullable>
+        <LangVersion>9.0</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/NationalInstruments.Analyzers.Utilities/AdditionalFileProvider.cs
+++ b/src/NationalInstruments.Analyzers.Utilities/AdditionalFileProvider.cs
@@ -39,7 +39,7 @@ namespace NationalInstruments.Analyzers.Utilities
         /// </summary>
         /// <param name="fileName">Name of the file, including extension, to return.</param>
         /// <returns>An additional file or <c>null</c> if no file can be found.</returns>
-        public AdditionalText GetFile(string fileName)
+        public AdditionalText? GetFile(string fileName)
             => _additionalFiles.FirstOrDefault(x => Path.GetFileName(x.Path).Equals(fileName, StringComparison.OrdinalIgnoreCase));
 
         /// <summary>

--- a/src/NationalInstruments.Analyzers.Utilities/AdditionalFileService.cs
+++ b/src/NationalInstruments.Analyzers.Utilities/AdditionalFileService.cs
@@ -45,7 +45,7 @@ namespace NationalInstruments.Analyzers.Utilities
         }
 
         /// <inheritdoc />
-        public XElement ParseXmlFile(AdditionalText xmlFile, CancellationToken cancellationToken = default(CancellationToken))
+        public XElement? ParseXmlFile(AdditionalText xmlFile, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -53,7 +53,7 @@ namespace NationalInstruments.Analyzers.Utilities
 
                 if (!cancellationToken.IsCancellationRequested)
                 {
-                    xml = xmlFile.GetText(cancellationToken).ToString();
+                    xml = xmlFile.GetText(cancellationToken)?.ToString();
                 }
 
                 if (!cancellationToken.IsCancellationRequested)

--- a/src/NationalInstruments.Analyzers.Utilities/AttributeCollection.cs
+++ b/src/NationalInstruments.Analyzers.Utilities/AttributeCollection.cs
@@ -81,8 +81,13 @@ namespace NationalInstruments.Analyzers.Utilities
         /// </summary>
         /// <param name="name">Name of the attribute.</param>
         /// <param name="value">Value of the attribute.</param>
-        public void Add(string name, string value)
+        public void Add(string name, string? value)
         {
+            if (value is null)
+            {
+                return;
+            }
+
             if (_attributes.TryGetValue(name, out var values))
             {
                 values.Add(value);
@@ -92,7 +97,7 @@ namespace NationalInstruments.Analyzers.Utilities
                 _attributes.Add(
                     name,
                     new HashSet<string>(
-                        value.Split("|".ToCharArray(), StringSplitOptions.RemoveEmptyEntries),
+                        value?.Split("|".ToCharArray(), StringSplitOptions.RemoveEmptyEntries),
                         StringComparer.OrdinalIgnoreCase));
             }
         }
@@ -138,9 +143,9 @@ namespace NationalInstruments.Analyzers.Utilities
         /// A Boolean that indicates that the <paramref name="attributes"/> either don't exist in this
         /// collection or their values match.
         /// </returns>
-        public bool MoreSpecificThan(AttributeCollection attributes)
+        public bool MoreSpecificThan(AttributeCollection? attributes)
         {
-            if (attributes == null)
+            if (attributes is null)
             {
                 return _attributes.Any();
             }
@@ -181,7 +186,7 @@ namespace NationalInstruments.Analyzers.Utilities
         /// <returns>A Boolean that indicates if this instance is equal to another.</returns>
         public override bool Equals(object obj)
         {
-            if (obj == null)
+            if (obj is null)
             {
                 return false; // 'this' cannot be null
             }
@@ -191,8 +196,7 @@ namespace NationalInstruments.Analyzers.Utilities
                 return true;
             }
 
-            var other = obj as AttributeCollection;
-            if (other == null)
+            if (obj is not AttributeCollection other)
             {
                 return false; // comparing against an object that isn't an 'AttributeSet'
             }

--- a/src/NationalInstruments.Analyzers.Utilities/ConfigurableAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers.Utilities/ConfigurableAnalyzer.cs
@@ -9,7 +9,7 @@ namespace NationalInstruments.Analyzers.Utilities
     /// </summary>
     public abstract class ConfigurableAnalyzer : StatefulAnalyzer
     {
-        private IAdditionalFileService _additionalFileService;
+        private readonly IAdditionalFileService _additionalFileService;
 
         /// <summary>
         /// Constructor that stores an implementation of <see cref="IAdditionalFileService"/>.
@@ -33,7 +33,7 @@ namespace NationalInstruments.Analyzers.Utilities
         {
             foreach (var file in _additionalFileService.GetFilesMatchingPattern(fileNamePattern))
             {
-                XElement configuration = _additionalFileService.ParseXmlFile(file, CancellationToken);
+                XElement? configuration = _additionalFileService.ParseXmlFile(file, CancellationToken);
                 if (configuration != null)
                 {
                     LoadConfigurations(configuration, file.Path);
@@ -56,8 +56,8 @@ namespace NationalInstruments.Analyzers.Utilities
         /// <param name="filePath">Full path to the XML file.</param>
         /// <param name="rule">Rule to use if the root element's name differs from the expected name.</param>
         /// <param name="diagnostic">Diagnostic to return as an out parameter if the root element's name differs from the expected name.</param>
-        /// <returns></returns>
-        protected bool TryGetRootElementDiagnostic(XElement rootElement, string expectedName, string filePath, DiagnosticDescriptor rule, out Diagnostic diagnostic)
+        /// <returns>True if a diagnostic was created, false otherwise.</returns>
+        protected bool TryGetRootElementDiagnostic(XElement rootElement, string expectedName, string filePath, DiagnosticDescriptor rule, out Diagnostic? diagnostic)
         {
             if (rootElement.Name != expectedName)
             {

--- a/src/NationalInstruments.Analyzers.Utilities/ExemptionCollection.cs
+++ b/src/NationalInstruments.Analyzers.Utilities/ExemptionCollection.cs
@@ -31,7 +31,7 @@ namespace NationalInstruments.Analyzers.Utilities
     /// </example>
     public sealed class ExemptionCollection : IEnumerable<string>
     {
-        private readonly Dictionary<Exemption, AttributeCollection> _exemptions = new Dictionary<Exemption, AttributeCollection>();
+        private readonly Dictionary<Exemption, AttributeCollection?> _exemptions = new Dictionary<Exemption, AttributeCollection?>();
 
         /// <summary>
         /// Default parameterless constructor.
@@ -45,7 +45,7 @@ namespace NationalInstruments.Analyzers.Utilities
         /// </summary>
         /// <param name="values">An array of exemption values.</param>
         public ExemptionCollection(params string[] values)
-            : this(values.Select(x => Tuple.Create<string, AttributeCollection>(x, null)).ToArray())
+            : this(values.Select(x => Tuple.Create<string, AttributeCollection?>(x, null)).ToArray())
         {
         }
 
@@ -53,11 +53,11 @@ namespace NationalInstruments.Analyzers.Utilities
         /// Constructor that accepts any number of value-attribute exemptions.
         /// </summary>
         /// <param name="exemptions">An array of tuples containing exemption value and associated attributes.</param>
-        public ExemptionCollection(params Tuple<string, AttributeCollection>[] exemptions)
+        public ExemptionCollection(params Tuple<string, AttributeCollection?>[] exemptions)
         {
             foreach (var exemption in exemptions)
             {
-                Add(exemption.Item1, exemption.Item2);
+                Add(exemption.Item1, exemption?.Item2);
             }
         }
 
@@ -71,7 +71,7 @@ namespace NationalInstruments.Analyzers.Utilities
         /// </summary>
         /// <param name="value">A string pattern that should be exempt.</param>
         /// <returns>A set of attributes that applies to this exemption.</returns>
-        public AttributeCollection this[string value] => _exemptions[new Exemption(value)];
+        public AttributeCollection? this[string value] => _exemptions[new Exemption(value)];
 
         /// <inheritdoc />
         public IEnumerator<string> GetEnumerator()
@@ -90,15 +90,15 @@ namespace NationalInstruments.Analyzers.Utilities
         /// </summary>
         /// <param name="value">A string pattern that should be exempt.</param>
         /// <param name="attributes">A set of attributes that applies to this exemption.</param>
-        public void Add(string value, AttributeCollection attributes = null)
+        public void Add(string? value, AttributeCollection? attributes = null)
         {
             var exemption = new Exemption(value);
 
             if (_exemptions.TryGetValue(exemption, out var existingAttributes))
             {
-                if (existingAttributes != null)
+                if (existingAttributes is not null)
                 {
-                    if (attributes != null)
+                    if (attributes is not null)
                     {
                         existingAttributes.Merge(attributes);
                     }
@@ -140,7 +140,7 @@ namespace NationalInstruments.Analyzers.Utilities
         /// <param name="value">Any string value.</param>
         /// <param name="attributes">A set of attributes that applies to the current <paramref name="value"/>.</param>
         /// <returns>A Boolean that indicates if the value/attributes combo is contained in/satisfied by this collection.</returns>
-        public bool Contains(string value, AttributeCollection attributes = null)
+        public bool Contains(string value, AttributeCollection? attributes = null)
         {
             if (_exemptions.TryGetValue(new Exemption(value), out var existingAttributes))
             {
@@ -158,7 +158,7 @@ namespace NationalInstruments.Analyzers.Utilities
         /// <param name="value">Any string value.</param>
         /// <param name="attributes">A set of attributes that applies to the current <paramref name="value"/>.</param>
         /// <returns>A Boolean that indicates f the value/attributes combo matches an entry in this collection.</returns>
-        public bool Matches(string value, AttributeCollection attributes = null)
+        public bool Matches(string value, AttributeCollection? attributes = null)
         {
             return _exemptions.Any(x => x.Key.Pattern.IsMatch(value) && (!x.Value?.MoreSpecificThan(attributes) ?? true));
         }
@@ -167,9 +167,9 @@ namespace NationalInstruments.Analyzers.Utilities
         {
             private readonly string _comparisonValue;
 
-            public Exemption(string value)
+            public Exemption(string? value)
             {
-                if (value == null)
+                if (value is null)
                 {
                     throw new ArgumentNullException(nameof(value));
                 }

--- a/src/NationalInstruments.Analyzers.Utilities/Extensions/IEnumerableExtensions.cs
+++ b/src/NationalInstruments.Analyzers.Utilities/Extensions/IEnumerableExtensions.cs
@@ -14,7 +14,7 @@ namespace NationalInstruments.Analyzers.Utilities.Extensions
         /// <typeparam name="T">Any type</typeparam>
         /// <param name="enumerable">The enumerable to return, or empty if null.</param>
         /// <returns><paramref name="enumerable"/>, or <see cref="Enumerable.Empty{T}"/> if null</returns>
-        public static IEnumerable<T> ToSafeEnumerable<T>(this IEnumerable<T> enumerable)
+        public static IEnumerable<T> ToSafeEnumerable<T>(this IEnumerable<T>? enumerable)
         {
             return enumerable ?? Enumerable.Empty<T>();
         }

--- a/src/NationalInstruments.Analyzers.Utilities/Extensions/IMethodSymbolExtensions.cs
+++ b/src/NationalInstruments.Analyzers.Utilities/Extensions/IMethodSymbolExtensions.cs
@@ -27,7 +27,7 @@ namespace NationalInstruments.Analyzers.Utilities.Extensions
                 return false;
             }
 
-            IMethodSymbol overridden = method.OverriddenMethod;
+            IMethodSymbol? overridden = method.OverriddenMethod;
 
             if (method.ContainingType.SpecialType == SpecialType.System_Object)
             {
@@ -40,12 +40,12 @@ namespace NationalInstruments.Analyzers.Utilities.Extensions
                 return false;
             }
 
-            for (IMethodSymbol o = overridden.OverriddenMethod; o != null; o = o.OverriddenMethod)
+            for (IMethodSymbol? o = overridden?.OverriddenMethod; o != null; o = o.OverriddenMethod)
             {
                 overridden = o;
             }
 
-            return overridden.ContainingType.SpecialType == SpecialType.System_Object; // it is object.Finalize
+            return overridden?.ContainingType.SpecialType == SpecialType.System_Object; // it is object.Finalize
         }
     }
 }

--- a/src/NationalInstruments.Analyzers.Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/NationalInstruments.Analyzers.Utilities/Extensions/ISymbolExtensions.cs
@@ -15,7 +15,7 @@ namespace NationalInstruments.Analyzers.Utilities.Extensions
         /// <returns>
         /// A string representing all the aspects of a symbol that make it uniquely identifiable, such as its fully-qualified parameters.
         /// </returns>
-        public static string GetFullName(this ISymbol symbol)
+        public static string? GetFullName(this ISymbol symbol)
         {
             if (symbol == null)
             {
@@ -52,18 +52,18 @@ namespace NationalInstruments.Analyzers.Utilities.Extensions
                 }
             }
 
-            IFieldSymbol field = null;
-            IPropertySymbol property = null;
-            if ((field = symbol as IFieldSymbol) != null || (property = symbol as IPropertySymbol) != null)
+            var fieldSymbol = symbol as IFieldSymbol;
+            var propertySymbol = symbol as IPropertySymbol;
+            if (fieldSymbol is not null || propertySymbol is not null)
             {
-                ITypeSymbol type = field?.Type ?? property?.Type;
-                prefix = type.ToDisplayString(SymbolDisplayFormats.FullyQualifiedParameters);
+                ITypeSymbol? type = fieldSymbol?.Type ?? propertySymbol?.Type;
+                prefix = type?.ToDisplayString(SymbolDisplayFormats.FullyQualifiedParameters);
             }
 
             // Always keep the removal of whitespace separate from the removal of the prefix. This will prevent
             // characters beyond the prefix from being removed.
             var symbolName = symbol.ToDisplayString(SymbolDisplayFormats.FullyQualifiedParameters)
-                .TrimStart(prefix.ToCharArray())
+                .TrimStart(prefix?.ToCharArray())
                 .TrimStart();
 
             symbolNameBuilder.Append(symbolName);

--- a/src/NationalInstruments.Analyzers.Utilities/Extensions/ITypeSymbolExtensions.cs
+++ b/src/NationalInstruments.Analyzers.Utilities/Extensions/ITypeSymbolExtensions.cs
@@ -23,8 +23,8 @@ namespace NationalInstruments.Analyzers.Utilities.Extensions
         /// <returns>Generator of INamedTypeSymbols where the next symbol returned is the base type of the previous one</returns>
         public static IEnumerable<ITypeSymbol> GetBaseTypesAndThis(this ITypeSymbol type)
         {
-            ITypeSymbol current = type;
-            while (current != null)
+            ITypeSymbol? current = type;
+            while (current is not null)
             {
                 yield return current;
                 current = current.BaseType;

--- a/src/NationalInstruments.Analyzers.Utilities/Extensions/StringExtensions.cs
+++ b/src/NationalInstruments.Analyzers.Utilities/Extensions/StringExtensions.cs
@@ -18,7 +18,7 @@ namespace NationalInstruments.Analyzers.Utilities.Extensions
         /// <param name="input">Any text.</param>
         /// <param name="wildcardPattern">Any text that optionally includes "wildcards", or asterisks.</param>
         /// <returns>True or false depending on whether the given input matches the given wildcard pattern or not.</returns>
-        public static bool MatchesWildcardPattern(this string input, string wildcardPattern)
+        public static bool MatchesWildcardPattern(this string? input, string? wildcardPattern)
         {
             var pattern = string.Concat("^", Regex.Escape(wildcardPattern).Replace(@"\*", ".*"), "$");
             return Regex.IsMatch(input, pattern, RegexOptions.IgnoreCase);

--- a/src/NationalInstruments.Analyzers.Utilities/Extensions/SyntaxNodeExtensions.cs
+++ b/src/NationalInstruments.Analyzers.Utilities/Extensions/SyntaxNodeExtensions.cs
@@ -19,9 +19,9 @@ namespace NationalInstruments.Analyzers.Utilities.Extensions
         /// <param name="node">Syntax node in a syntax tree.</param>
         /// <param name="model">Semantic model for the syntax tree containing the <paramref name="node"/>.</param>
         /// <returns>Symbol represented by the provided syntax.</returns>
-        public static ISymbol GetDeclaredOrReferencedSymbol(this SyntaxNode node, SemanticModel model)
+        public static ISymbol? GetDeclaredOrReferencedSymbol(this SyntaxNode? node, SemanticModel model)
         {
-            return node != null ? model.GetDeclaredSymbol(node) ?? model.GetSymbolInfo(node).Symbol : null;
+            return node is not null ? model.GetDeclaredSymbol(node) ?? model.GetSymbolInfo(node).Symbol : null;
         }
 
         /// <summary>

--- a/src/NationalInstruments.Analyzers.Utilities/IAdditionalFileService.cs
+++ b/src/NationalInstruments.Analyzers.Utilities/IAdditionalFileService.cs
@@ -34,6 +34,6 @@ namespace NationalInstruments.Analyzers.Utilities
         /// <param name="xmlFile">An <see cref="AdditionalText" /> file that should have XML contents.</param>
         /// <param name="cancellationToken">A token that allows text retrieval/parsing to be canceled prior to completion.</param>
         /// <returns>The <see cref="XElement" /> root node.</returns>
-        XElement ParseXmlFile(AdditionalText xmlFile, CancellationToken cancellationToken);
+        XElement? ParseXmlFile(AdditionalText xmlFile, CancellationToken cancellationToken);
     }
 }

--- a/src/NationalInstruments.Analyzers.Utilities/Text/WordParser.cs
+++ b/src/NationalInstruments.Analyzers.Utilities/Text/WordParser.cs
@@ -52,7 +52,7 @@ namespace NationalInstruments.Analyzers.Utilities.Text
         private readonly WordParserOptions _options;
         private readonly StringBuilder _buffer;
         private readonly string _text;
-        private string _peekedWord;
+        private string? _peekedWord;
         private int _index;
         private char _prefix;
 
@@ -71,7 +71,7 @@ namespace NationalInstruments.Analyzers.Utilities.Text
         /// <exception cref="ArgumentException">
         ///     <paramref name="options"/> is not one or more of the <see cref="WordParserOptions"/> values.
         /// </exception>
-        public WordParser(string text, WordParserOptions options)
+        public WordParser(string? text, WordParserOptions options)
             : this(text, options, NullChar)
         {
         }
@@ -95,7 +95,7 @@ namespace NationalInstruments.Analyzers.Utilities.Text
         /// <exception cref="ArgumentException">
         ///     <paramref name="options"/> is not one or more of the <see cref="WordParserOptions"/> values.
         /// </exception>
-        public WordParser(string text, WordParserOptions options, char prefix)
+        public WordParser(string? text, WordParserOptions options, char prefix)
         {
             if (options < WordParserOptions.None || options > (WordParserOptions.IgnoreMnemonicsIndicators | WordParserOptions.SplitCompoundWords))
             {
@@ -139,7 +139,7 @@ namespace NationalInstruments.Analyzers.Utilities.Text
         /// <exception cref="ArgumentException">
         ///     <paramref name="options"/> is not one or more of the <see cref="WordParserOptions"/> values.
         /// </exception>
-        public static bool ContainsWord(string text, WordParserOptions options, ImmutableArray<string> words)
+        public static bool ContainsWord(string? text, WordParserOptions options, ImmutableArray<string> words)
         {
             return ContainsWord(text, options, NullChar, words);
         }
@@ -150,7 +150,7 @@ namespace NationalInstruments.Analyzers.Utilities.Text
         /// <returns>
         ///     A <see cref="string"/> containing the next word or <see langword="null"/> if there are no more words.
         /// </returns>
-        public string NextWord()
+        public string? NextWord()
         {
             if (_peekedWord == null)
             {
@@ -168,7 +168,7 @@ namespace NationalInstruments.Analyzers.Utilities.Text
         /// <returns>
         ///     A <see cref="string"/> containing the next word or <see langword="null"/> if there are no more words.
         /// </returns>
-        public string PeekWord()
+        public string? PeekWord()
         {
             if (_peekedWord == null)
             {
@@ -196,7 +196,7 @@ namespace NationalInstruments.Analyzers.Utilities.Text
         /// <exception cref="ArgumentException">
         ///     <paramref name="options"/> is not one or more of the <see cref="WordParserOptions"/> values.
         /// </exception>
-        public static Collection<string> Parse(string text, WordParserOptions options)
+        public static Collection<string> Parse(string? text, WordParserOptions options)
         {
             return Parse(text, options, NullChar);
         }
@@ -223,13 +223,13 @@ namespace NationalInstruments.Analyzers.Utilities.Text
         /// <exception cref="ArgumentException">
         ///     <paramref name="options"/> is not one or more of the <see cref="WordParserOptions"/> values.
         /// </exception>
-        public static Collection<string> Parse(string text, WordParserOptions options, char prefix)
+        public static Collection<string> Parse(string? text, WordParserOptions options, char prefix)
         {
             var parser = new WordParser(text, options, prefix);
             var words = new Collection<string>();
 
-            string word;
-            while ((word = parser.NextWord()) != null)
+            string? word;
+            while ((word = parser.NextWord()) is not null)
             {
                 words.Add(word);
             }
@@ -266,7 +266,7 @@ namespace NationalInstruments.Analyzers.Utilities.Text
         /// <exception cref="ArgumentException">
         ///     <paramref name="options"/> is not one or more of the <see cref="WordParserOptions"/> values.
         /// </exception>
-        public static bool ContainsWord(string text, WordParserOptions options, char prefix, ImmutableArray<string> words)
+        public static bool ContainsWord(string? text, WordParserOptions options, char prefix, ImmutableArray<string> words)
         {
             if (words.IsDefault)
             {
@@ -275,7 +275,7 @@ namespace NationalInstruments.Analyzers.Utilities.Text
 
             var parser = new WordParser(text, options, prefix);
 
-            string parsedWord;
+            string? parsedWord;
             while ((parsedWord = parser.NextWord()) != null)
             {
                 foreach (var word in words)
@@ -354,7 +354,7 @@ namespace NationalInstruments.Analyzers.Utilities.Text
             return false;
         }
 
-        private string NextWordCore()
+        private string? NextWordCore()
         {
             // Reset buffer
             _buffer.Length = 0;

--- a/src/NationalInstruments.Analyzers.Utilities/WellKnownTypes.cs
+++ b/src/NationalInstruments.Analyzers.Utilities/WellKnownTypes.cs
@@ -5,9 +5,9 @@ namespace NationalInstruments.Analyzers.Utilities
     public static class WellKnownTypes
     {
 #pragma warning disable CA1720 // Identifier contains type name
-        public static INamedTypeSymbol Object(Compilation compilation) => compilation.GetTypeByMetadataName("System.Object");
+        public static INamedTypeSymbol? Object(Compilation compilation) => compilation.GetTypeByMetadataName("System.Object");
 #pragma warning restore CA1720 // Identifier contains type name
 
-        public static INamedTypeSymbol IWeakEventListener(Compilation compilation) => compilation.GetTypeByMetadataName("System.Windows.IWeakEventListener");
+        public static INamedTypeSymbol? IWeakEventListener(Compilation compilation) => compilation.GetTypeByMetadataName("System.Windows.IWeakEventListener");
     }
 }

--- a/src/NationalInstruments.Analyzers/Correctness/AllTypesInNationalInstrumentsNamespaceAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/AllTypesInNationalInstrumentsNamespaceAnalyzer.cs
@@ -99,11 +99,12 @@ namespace NationalInstruments.Analyzers.Correctness
             {
                 var namespaceSyntax = (NamespaceDeclarationSyntax)context.Node;
                 var @namespace = namespaceSyntax.GetDeclaredOrReferencedSymbol(context.SemanticModel);
-                var namespaceName = @namespace.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).TrimStart("global:".ToCharArray());
+                var namespaceName = @namespace?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).TrimStart("global:".ToCharArray());
 
                 // Bail out if this namespace already is/starts with 'NationalInstruments[.]' or is exempt
-                if (Regex.IsMatch(namespaceName, string.Format(CultureInfo.InvariantCulture, @"^{0}(\s|\b)", CorrectNamespace), RegexOptions.IgnoreCase)
-                    || _exemptNamespaces.Contains(namespaceName))
+                if (namespaceName is not null
+                    && (Regex.IsMatch(namespaceName, string.Format(CultureInfo.InvariantCulture, @"^{0}(\s|\b)", CorrectNamespace), RegexOptions.IgnoreCase)
+                    || _exemptNamespaces.Contains(namespaceName)))
                 {
                     return;
                 }
@@ -120,7 +121,7 @@ namespace NationalInstruments.Analyzers.Correctness
             {
                 if (TryGetRootElementDiagnostic(rootElement, "ExemptNamespaces", filePath, FileParseRule, out var diagnostic))
                 {
-                    _additionalFileService.ParsingDiagnostics.Add(diagnostic);
+                    _additionalFileService.ParsingDiagnostics.Add(diagnostic!);
                 }
 
                 _exemptNamespaces.UnionWith(rootElement.Elements("Entry").Select(x => x.Value.Trim()));

--- a/src/NationalInstruments.Analyzers/Correctness/AwaitInReadLockOrTransactionAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/AwaitInReadLockOrTransactionAnalyzer.cs
@@ -73,8 +73,8 @@ namespace NationalInstruments.Analyzers.Correctness
             }
 
             var usingAcquiresLock = false;
-            var memberAccessSyntaxes = (usingStatementSyntax.Declaration?.DescendantNodes().OfType<MemberAccessExpressionSyntax>()).ToSafeEnumerable()
-                .Concat((usingStatementSyntax.Expression?.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>()).ToSafeEnumerable());
+            var memberAccessSyntaxes = (usingStatementSyntax?.Declaration?.DescendantNodes().OfType<MemberAccessExpressionSyntax>()).ToSafeEnumerable()
+                .Concat((usingStatementSyntax?.Expression?.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>()).ToSafeEnumerable());
             foreach (var memberAccessSyntax in memberAccessSyntaxes)
             {
                 // If it's an array, pointer, or type parameter we can ignore it anyway, so cast to INamedTypeSymbol.
@@ -109,8 +109,9 @@ namespace NationalInstruments.Analyzers.Correctness
 
             if (usingAcquiresLock)
             {
-                var bodySyntax = usingStatementSyntax.Statement;
-                foreach (var awaitExpressionSyntax in bodySyntax.DescendantNodesAndSelf().OfType<AwaitExpressionSyntax>())
+                var bodySyntax = usingStatementSyntax?.Statement;
+                foreach (var awaitExpressionSyntax in
+                    (bodySyntax?.DescendantNodesAndSelf().OfType<AwaitExpressionSyntax>()).ToSafeEnumerable())
                 {
                     var diagnostic = Diagnostic.Create(Rule, awaitExpressionSyntax.GetLocation());
                     context.ReportDiagnostic(diagnostic);

--- a/src/NationalInstruments.Analyzers/Correctness/DatabaseColumnsShouldBeNullableAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/DatabaseColumnsShouldBeNullableAnalyzer.cs
@@ -54,7 +54,7 @@ namespace NationalInstruments.Analyzers.Correctness
             var classDeclaration = (ClassDeclarationSyntax)context.Node;
             var classSymbol = classDeclaration.GetDeclaredOrReferencedSymbol(context.SemanticModel) as INamedTypeSymbol;
 
-            if (!classSymbol.IsOrInheritsFromClass("Microsoft.EntityFrameworkCore.DbContext"))
+            if (!classSymbol?.IsOrInheritsFromClass("Microsoft.EntityFrameworkCore.DbContext") ?? false)
             {
                 return;
             }
@@ -65,7 +65,7 @@ namespace NationalInstruments.Analyzers.Correctness
             {
                 var propertyType = property.Type.GetDeclaredOrReferencedSymbol(context.SemanticModel) as INamedTypeSymbol;
 
-                if (propertyType.ConstructedFrom.GetFullName() != "Microsoft.EntityFrameworkCore.DbSet<T>")
+                if (propertyType?.ConstructedFrom.GetFullName() != "Microsoft.EntityFrameworkCore.DbSet<T>")
                 {
                     continue;
                 }
@@ -79,9 +79,9 @@ namespace NationalInstruments.Analyzers.Correctness
             }
         }
 
-        private void CheckType(INamedTypeSymbol type, IPropertySymbol declaringProperty, SyntaxNodeAnalysisContext context, bool allowValueType = false)
+        private void CheckType(INamedTypeSymbol? type, IPropertySymbol? declaringProperty, SyntaxNodeAnalysisContext context, bool allowValueType = false)
         {
-            if (type.SpecialType == SpecialType.System_String)
+            if (type is null || type.SpecialType == SpecialType.System_String)
             {
                 // String is special because it's a fundamental DB type
                 return;
@@ -131,8 +131,8 @@ namespace NationalInstruments.Analyzers.Correctness
         private void CheckProperty(IPropertySymbol property, SyntaxNodeAnalysisContext context)
         {
             bool AllowsValueType(AttributeData x) =>
-                x.AttributeClass.ToString() == "System.ComponentModel.DataAnnotations.Schema.NotMappedAttribute"
-                || x.AttributeClass.ToString() == "System.ComponentModel.DataAnnotations.KeyAttribute";
+                x.AttributeClass?.ToString() == "System.ComponentModel.DataAnnotations.Schema.NotMappedAttribute"
+                || x.AttributeClass?.ToString() == "System.ComponentModel.DataAnnotations.KeyAttribute";
 
             if (property.GetAttributes().Any(AllowsValueType))
             {
@@ -150,9 +150,9 @@ namespace NationalInstruments.Analyzers.Correctness
             CheckType(property.Type as INamedTypeSymbol, property, context);
         }
 
-        private void ReportDiagnostic(SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, INamedTypeSymbol type, IPropertySymbol property)
+        private void ReportDiagnostic(SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, INamedTypeSymbol type, IPropertySymbol? property)
         {
-            var diagnostic = Diagnostic.Create(descriptor, property.Locations.First(), type.Name, property.Name, property.ContainingType.Name);
+            var diagnostic = Diagnostic.Create(descriptor, property?.Locations.First(), type.Name, property?.Name, property?.ContainingType.Name);
             context.ReportDiagnostic(diagnostic);
         }
     }

--- a/src/NationalInstruments.Analyzers/Correctness/DoNotLockDirectlyOnPrivateMemberLockAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/DoNotLockDirectlyOnPrivateMemberLockAnalyzer.cs
@@ -44,9 +44,9 @@ namespace NationalInstruments.Analyzers.Correctness
             }
         }
 
-        private bool TypeIsPrivateMemberLock(INamedTypeSymbol type)
+        private bool TypeIsPrivateMemberLock(INamedTypeSymbol? type)
         {
-            return type.IsOrInheritsFromClass("NationalInstruments.Core.PrivateMemberLock");
+            return type?.IsOrInheritsFromClass("NationalInstruments.Core.PrivateMemberLock") ?? false;
         }
     }
 }

--- a/src/NationalInstruments.Analyzers/Correctness/DoNotUseBannedMethodsAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/DoNotUseBannedMethodsAnalyzer.cs
@@ -110,7 +110,7 @@ namespace NationalInstruments.Analyzers.Correctness
                     return;
                 }
 
-                ISymbol invocation = invocationSyntax.GetDeclaredOrReferencedSymbol(context.SemanticModel);
+                ISymbol? invocation = invocationSyntax.GetDeclaredOrReferencedSymbol(context.SemanticModel);
                 var fullName = invocation?.GetFullName();
                 if (string.IsNullOrEmpty(fullName))
                 {
@@ -119,7 +119,7 @@ namespace NationalInstruments.Analyzers.Correctness
 
                 foreach (var bannedMatch in _bannedMethods.Where(analyzerEntry => analyzerEntry.EntryRegex.IsMatch(fullName)))
                 {
-                    if (bannedMatch.IsBannedInThisAssembly(context.ContainingSymbol.ContainingAssembly))
+                    if (bannedMatch.IsBannedInThisAssembly(context.ContainingSymbol?.ContainingAssembly))
                     {
                         var diagnostic = Diagnostic.Create(Rule, invocationSyntax.GetLocation(), fullName, bannedMatch.AdditionalErrorMessage);
                         context.ReportDiagnostic(diagnostic);
@@ -132,7 +132,7 @@ namespace NationalInstruments.Analyzers.Correctness
             {
                 if (TryGetRootElementDiagnostic(rootElement, "BannedMethods", filePath, FileParseRule, out var diagnostic))
                 {
-                    _additionalFileService.ParsingDiagnostics.Add(diagnostic);
+                    _additionalFileService.ParsingDiagnostics.Add(diagnostic!);
                 }
 
                 foreach (XElement element in rootElement.Elements())
@@ -181,17 +181,17 @@ namespace NationalInstruments.Analyzers.Correctness
 
                 public AnalyzerEntryOptionsForParsing WithJustification(string justification)
                 {
-                    return new AnalyzerEntryOptionsForParsing(justification?.Trim(), Alternative, Assemblies);
+                    return new AnalyzerEntryOptionsForParsing(justification.Trim(), Alternative, Assemblies);
                 }
 
                 public AnalyzerEntryOptionsForParsing WithAlternative(string alternative)
                 {
-                    return new AnalyzerEntryOptionsForParsing(Justification, alternative?.Trim(), Assemblies);
+                    return new AnalyzerEntryOptionsForParsing(Justification, alternative.Trim(), Assemblies);
                 }
 
                 public AnalyzerEntryOptionsForParsing WithAssemblies(string assemblies)
                 {
-                    return new AnalyzerEntryOptionsForParsing(Justification, Alternative, assemblies?.Trim());
+                    return new AnalyzerEntryOptionsForParsing(Justification, Alternative, assemblies.Trim());
                 }
 
                 public AnalyzerEntryOptionsForParsing UpdateFromElement(XElement element)
@@ -225,6 +225,7 @@ namespace NationalInstruments.Analyzers.Correctness
                     EntryRegex = GetEscapedRegex(EntryName);
                     Justification = options.Justification;
                     Alternative = options.Alternative;
+                    Assemblies = options.Assemblies;
                     AssemblyRegexes = !string.IsNullOrWhiteSpace(options.Assemblies)
                         ? options.Assemblies.Trim().Split(',').Select(x => GetEscapedRegex(x))
                         : new List<Regex>();
@@ -270,9 +271,9 @@ namespace NationalInstruments.Analyzers.Correctness
 
                 public static bool operator !=(AnalyzerEntry entry1, AnalyzerEntry entry2) => !(entry1 == entry2);
 
-                public bool IsBannedInThisAssembly(IAssemblySymbol assemblySymbol)
+                public bool IsBannedInThisAssembly(IAssemblySymbol? assemblySymbol)
                 {
-                    return !AssemblyRegexes.Any() || AssemblyRegexes.Any(regex => regex.IsMatch(assemblySymbol.Name));
+                    return !AssemblyRegexes.Any() || AssemblyRegexes.Any(regex => regex.IsMatch(assemblySymbol?.Name));
                 }
 
                 public override bool Equals(object obj)
@@ -293,9 +294,9 @@ namespace NationalInstruments.Analyzers.Correctness
                     return hashCode;
                 }
 
-                public bool Equals(AnalyzerEntry other)
+                public bool Equals(AnalyzerEntry? other)
                 {
-                    return other != null
+                    return other is not null
                         && EntryName == other.EntryName
                         && Justification == other.Justification
                         && Alternative == other.Alternative

--- a/src/NationalInstruments.Analyzers/Correctness/ReceiveWeakEventMustReturnTrueAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/ReceiveWeakEventMustReturnTrueAnalyzer.cs
@@ -64,13 +64,14 @@ namespace NationalInstruments.Analyzers.Correctness
                 return;
             }
 
-            ISymbol receiveWeakEventMethod = WellKnownTypes.IWeakEventListener(context.Compilation)
-                .GetMembers(ReceiveWeakEventMethodName).Single();
+            ISymbol? receiveWeakEventMethod = WellKnownTypes.IWeakEventListener(context.Compilation)
+                ?.GetMembers(ReceiveWeakEventMethodName)
+                .Single();
 
             // Is this method implementing IWeakEventListener's ReceiveWeakEvent?
-            ISymbol method = context.SemanticModel.GetDeclaredSymbol(methodSyntax);
-            ISymbol implementation = method.ContainingType.FindImplementationForInterfaceMember(receiveWeakEventMethod);
-            if (implementation == null || !implementation.Equals(method, SymbolEqualityComparer.Default))
+            ISymbol? method = context.SemanticModel.GetDeclaredSymbol(methodSyntax);
+            ISymbol? implementation = receiveWeakEventMethod is null ? null : method?.ContainingType.FindImplementationForInterfaceMember(receiveWeakEventMethod);
+            if (implementation is null || !implementation.Equals(method, SymbolEqualityComparer.Default))
             {
                 return;
             }

--- a/src/NationalInstruments.Analyzers/Correctness/ReferencedInternalMustHaveVisibleInternalAttributeAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/ReferencedInternalMustHaveVisibleInternalAttributeAnalyzer.cs
@@ -89,8 +89,8 @@ namespace NationalInstruments.Analyzers.Correctness
         public void AnalyzeExpression(SyntaxNodeAnalysisContext context)
         {
             SyntaxNode node = context.Node;
-            ISymbol symbol = node.GetDeclaredOrReferencedSymbol(context.SemanticModel);
-            if (symbol == null)
+            ISymbol? symbol = node.GetDeclaredOrReferencedSymbol(context.SemanticModel);
+            if (symbol is null)
             {
                 return;
             }
@@ -101,13 +101,13 @@ namespace NationalInstruments.Analyzers.Correctness
             }
 
             IAssemblySymbol referencedAssembly = symbol.ContainingAssembly;
-            IAssemblySymbol callingAssembly = context.ContainingSymbol.ContainingAssembly;
+            IAssemblySymbol? callingAssembly = context.ContainingSymbol?.ContainingAssembly;
             if (referencedAssembly.Equals(callingAssembly, SymbolEqualityComparer.Default))
             {
                 return;
             }
 
-            IEnumerable<string> attributeNames = symbol.GetAttributes().Select(attribute => attribute.AttributeClass.Name);
+            IEnumerable<string?> attributeNames = symbol.GetAttributes().Select(attribute => attribute.AttributeClass?.Name);
             if (attributeNames.Contains("VisibleInternalAttribute", StringComparer.Ordinal))
             {
                 return;

--- a/src/NationalInstruments.Analyzers/Correctness/StringsShouldBeInResources/AttributeMissingTargetException.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/StringsShouldBeInResources/AttributeMissingTargetException.cs
@@ -49,11 +49,11 @@ namespace NationalInstruments.Analyzers.Correctness.StringsShouldBeInResources
         /// <summary>
         /// Name of the attribute missing a target value.
         /// </summary>
-        public string AttributeName { get; private set; }
+        public string? AttributeName { get; private set; }
 
         /// <summary>
         /// Name of the attribute's scope.
         /// </summary>
-        public string ScopeName { get; private set; }
+        public string? ScopeName { get; private set; }
     }
 }

--- a/src/NationalInstruments.Analyzers/Correctness/StringsShouldBeInResources/ExemptionAttribute.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/StringsShouldBeInResources/ExemptionAttribute.cs
@@ -38,21 +38,21 @@ namespace NationalInstruments.Analyzers.Correctness.StringsShouldBeInResources
             Scope = exemptionScope;
         }
 
-        public string Name => _attributeData.AttributeClass.Name;
+        public string? Name => _attributeData.AttributeClass?.Name;
 
         public ExemptionScope Scope { get; }
 
-        public string Target => GetNamedArgumentValueOrDefault("Target");
+        public string? Target => GetNamedArgumentValueOrDefault("Target");
 
-        public string Literal => _attributeData.ConstructorArguments.FirstOrDefault().Value?.ToString()
+        public string? Literal => _attributeData.ConstructorArguments.FirstOrDefault().Value?.ToString()
                                  ?? GetNamedArgumentValueOrDefault("Literal");
 
-        public static string GetTargetFromAttribute(ExemptionAttribute exemptionAttribute)
+        public static string? GetTargetFromAttribute(ExemptionAttribute exemptionAttribute)
         {
             return GetTargetFromAttributeOrSymbol<ISymbol>(exemptionAttribute, null);
         }
 
-        internal static string GetTargetFromAttributeOrSymbol<TExpected>(ExemptionAttribute exemptionAttribute, ISymbol decoratedSymbol)
+        internal static string? GetTargetFromAttributeOrSymbol<TExpected>(ExemptionAttribute exemptionAttribute, ISymbol? decoratedSymbol)
         {
             if (!string.IsNullOrWhiteSpace(exemptionAttribute.Target))
             {
@@ -69,11 +69,11 @@ namespace NationalInstruments.Analyzers.Correctness.StringsShouldBeInResources
 
             throw new AttributeMissingTargetException(
                 string.Format(CultureInfo.CurrentCulture, "Attribute {0} is missing a Target value.", attributeName),
-                attributeName,
+                attributeName ?? "Unknown attribute",
                 scopeName);
         }
 
-        private string GetNamedArgumentValueOrDefault(string argumentName)
+        private string? GetNamedArgumentValueOrDefault(string argumentName)
         {
             return _attributeData.NamedArguments.FirstOrDefault(x => x.Key == argumentName).Value.Value?.ToString();
         }

--- a/src/NationalInstruments.Analyzers/Correctness/TestClassesMustInheritFromAutoTestAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/TestClassesMustInheritFromAutoTestAnalyzer.cs
@@ -67,7 +67,7 @@ namespace NationalInstruments.Analyzers.Correctness
             var hasTestAttribute = classSyntax
                 .DescendantNodes()
                 .OfType<AttributeSyntax>()
-                .Any(syntax => context.SemanticModel.GetTypeInfo(syntax).Type.ToString().Equals(TestClassAttributeTypeName, StringComparison.OrdinalIgnoreCase));
+                .Any(syntax => context.SemanticModel?.GetTypeInfo(syntax).Type?.ToString().Equals(TestClassAttributeTypeName, StringComparison.OrdinalIgnoreCase) ?? false);
 
             if (!hasTestAttribute)
             {
@@ -76,7 +76,7 @@ namespace NationalInstruments.Analyzers.Correctness
 
             // Yes, this is a [TestClass]. Does it inherit from NI's AutoTest?
             var testClass = classSyntax.GetDeclaredOrReferencedSymbol(context.SemanticModel) as INamedTypeSymbol;
-            if (!testClass.GetBaseTypesAndThis().Any(x => x.ToString().Equals(NIAutoTestAttributeTypeName, StringComparison.OrdinalIgnoreCase)))
+            if (!testClass?.GetBaseTypesAndThis().Any(x => x.ToString().Equals(NIAutoTestAttributeTypeName, StringComparison.OrdinalIgnoreCase)) ?? false)
             {
                 var diagnostic = Diagnostic.Create(Rule, classSyntax.GetLocation(), classSyntax.Identifier.ToString());
                 context.ReportDiagnostic(diagnostic);

--- a/src/NationalInstruments.Analyzers/Correctness/ThereIsOnlyOneRestrictedNamespaceAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/ThereIsOnlyOneRestrictedNamespaceAnalyzer.cs
@@ -54,9 +54,9 @@ namespace NationalInstruments.Analyzers.Correctness
             context.RegisterSyntaxNodeAction(AnalyzeNamespaceSyntax, SyntaxKind.NamespaceDeclaration);
         }
 
-        private static bool IsNamespaceNameViolatingRule(string namespaceName)
+        private static bool IsNamespaceNameViolatingRule(string? namespaceName)
         {
-            return namespaceName != null
+            return namespaceName is not null
                 && namespaceName.IndexOf("Restricted", StringComparison.OrdinalIgnoreCase) >= 0
                 && !namespaceName.StartsWith(RestrictedNamespacePrefix, StringComparison.OrdinalIgnoreCase);
         }
@@ -73,7 +73,7 @@ namespace NationalInstruments.Analyzers.Correctness
                 // the case and there shouldn't be a violation, apply the same test against the fully-qualified
                 // namespace name.
                 var @namespace = namespaceSyntax.GetDeclaredOrReferencedSymbol(context.SemanticModel);
-                var namespaceName = @namespace.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).TrimStart("global:".ToCharArray());
+                var namespaceName = @namespace?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).TrimStart("global:".ToCharArray());
 
                 if (IsNamespaceNameViolatingRule(namespaceName))
                 {

--- a/src/NationalInstruments.Analyzers/Style/DoNotUseLinqQuerySyntax/DoNotUseLinqQuerySyntaxCodeFixProvider.cs
+++ b/src/NationalInstruments.Analyzers/Style/DoNotUseLinqQuerySyntax/DoNotUseLinqQuerySyntaxCodeFixProvider.cs
@@ -40,10 +40,13 @@ namespace NationalInstruments.Analyzers.Style.DoNotUseLinqQuerySyntax
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
-            var rewriter = new QueryComprehensionToFluentRewriter(semanticModel);
-            var oldExpression = root.FindNode(sourceSpan, getInnermostNodeForTie: true);
-            var newExpression = rewriter.Visit(oldExpression);
-            editor.ReplaceNode(oldExpression, newExpression);
+            if (root is not null && semanticModel is not null)
+            {
+                var rewriter = new QueryComprehensionToFluentRewriter(semanticModel);
+                var oldExpression = root.FindNode(sourceSpan, getInnermostNodeForTie: true);
+                var newExpression = rewriter.Visit(oldExpression);
+                editor.ReplaceNode(oldExpression, newExpression);
+            }
 
             return editor.GetChangedDocument();
         }

--- a/src/NationalInstruments.Analyzers/Style/SpellingAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Style/SpellingAnalyzer.cs
@@ -341,17 +341,18 @@ namespace NationalInstruments.Analyzers.Style
             IEnumerable<CodeAnalysisDictionary> ReadDictionaries()
             {
                 var fileProvider = AdditionalFileProvider.FromOptions(compilationStartContext.Options);
-                return fileProvider.GetMatchingFiles(@"(?:dictionary|custom).*?\.(?:xml|dic)$")
+                return fileProvider?.GetMatchingFiles(@"(?:dictionary|custom).*?\.(?:xml|dic)$")
                     .Select(CreateDictionaryFromAdditionalText)
-                    .Where(x => x != null);
+                    .OfType<CodeAnalysisDictionary>() ?? Enumerable.Empty<CodeAnalysisDictionary>();
 
-                CodeAnalysisDictionary CreateDictionaryFromAdditionalText(AdditionalText additionalFile)
+                CodeAnalysisDictionary? CreateDictionaryFromAdditionalText(AdditionalText additionalFile)
                 {
+                    CodeAnalysisDictionary? dictionary = null;
                     var text = additionalFile.GetText(compilationStartContext.CancellationToken);
                     var isXml = additionalFile.Path.EndsWith("xml", StringComparison.OrdinalIgnoreCase);
                     var provider = isXml ? _xmlDictionaryProvider : _dicDictionaryProvider;
 
-                    if (!compilationStartContext.TryGetValue(text, provider, out var dictionary))
+                    if (text is not null && !compilationStartContext.TryGetValue(text, provider, out dictionary))
                     {
                         try
                         {
@@ -479,9 +480,9 @@ namespace NationalInstruments.Analyzers.Style
             IEnumerable<string> GetMisspelledWords(string symbolName)
             {
                 var parser = new WordParser(symbolName, WordParserOptions.SplitCompoundWords);
-                if (parser.PeekWord() != null)
+                if (parser.PeekWord() is not null)
                 {
-                    var word = parser.NextWord();
+                    var word = parser.NextWord()!;
 
                     do
                     {
@@ -492,7 +493,7 @@ namespace NationalInstruments.Analyzers.Style
 
                         yield return word;
                     }
-                    while ((word = parser.NextWord()) != null);
+                    while ((word = parser.NextWord()) is not null);
                 }
             }
 

--- a/tests/NationalInstruments.Analyzers.TestUtilities.UnitTests/DiagnosticVerifierTests.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities.UnitTests/DiagnosticVerifierTests.cs
@@ -310,7 +310,7 @@ class Program
             return new Rule(ExampleDiagnosticAnalyzer.NoArgumentRule);
         }
 
-        private Rule GetExampleDiagnosticFieldRule(string fieldName = null)
+        private Rule GetExampleDiagnosticFieldRule(string? fieldName = null)
         {
             return new Rule(ExampleDiagnosticAnalyzer.OneArgumentRule, fieldName);
         }

--- a/tests/NationalInstruments.Analyzers.TestUtilities/TestAdditionalDocument.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities/TestAdditionalDocument.cs
@@ -26,9 +26,9 @@ namespace NationalInstruments.Analyzers.TestUtilities
         {
         }
 
-        public TestAdditionalDocument(string filePath, string fileName, string text)
+        public TestAdditionalDocument(string? filePath, string fileName, string text)
         {
-            Path = filePath;
+            Path = filePath ?? string.Empty;
             Name = fileName;
             _sourceText = SourceText.From(text);
         }
@@ -37,6 +37,6 @@ namespace NationalInstruments.Analyzers.TestUtilities
 
         public string Name { get; }
 
-        public override SourceText GetText(CancellationToken cancellationToken = default(CancellationToken)) => _sourceText;
+        public override SourceText GetText(CancellationToken cancellationToken = default) => _sourceText;
     }
 }

--- a/tests/NationalInstruments.Analyzers.TestUtilities/TestFiles/AutoTestFile.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities/TestFiles/AutoTestFile.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using NationalInstruments.Analyzers.TestUtilities.Markers;
 using NationalInstruments.Analyzers.TestUtilities.Verifiers;
 using Xunit;
@@ -25,14 +26,14 @@ namespace NationalInstruments.Analyzers.TestUtilities.TestFiles
         {
         }
 
-        public AutoTestFile(string name, string projectName, string source, params Rule[] violatedRules)
+        public AutoTestFile(string? name, string projectName, string source, params Rule[] violatedRules)
             : this(name, projectName, source, Enumerable.Empty<string>(), violatedRules)
         {
         }
 
-        public AutoTestFile(string name, string projectName, string source, IEnumerable<string> referencedProjectNames, params Rule[] violatedRules)
+        public AutoTestFile(string? name, string projectName, string source, IEnumerable<string> referencedProjectNames, params Rule[] violatedRules)
         {
-            Name = name;
+            Name = name ?? "Test0.cs";
             ProjectName = projectName;
             ReferencedProjectNames = referencedProjectNames;
 
@@ -63,7 +64,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.TestFiles
 
         public static bool operator !=(AutoTestFile left, AutoTestFile right) => !(left == right);
 
-        public override bool Equals(object obj) => !(obj is AutoTestFile) ? false : Equals((AutoTestFile)obj);
+        public override bool Equals(object obj) => obj is AutoTestFile file && Equals(file);
 
         public override int GetHashCode()
         {
@@ -93,11 +94,16 @@ namespace NationalInstruments.Analyzers.TestUtilities.TestFiles
                 yield break;
             }
 
-            Assert.True(markers.Count == violatedRules.Length, "Number of markers should always equal the number of violated rules");
+            Assert.True(markers?.Count == violatedRules?.Length, "Number of markers should always equal the number of violated rules");
 
-            for (var i = 0; i < markers.Count; ++i)
+            for (var i = 0; i < markers?.Count; ++i)
             {
-                var rule = violatedRules[i];
+                if (violatedRules is null)
+                {
+                    continue;
+                }
+
+                Rule rule = violatedRules[i];
                 var marker = markers[i];
                 var arguments = Enumerable.Empty<object>();
 

--- a/tests/NationalInstruments.Analyzers.TestUtilities/TestFiles/TestFile.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities/TestFiles/TestFile.cs
@@ -20,14 +20,14 @@ namespace NationalInstruments.Analyzers.TestUtilities.TestFiles
         {
         }
 
-        public TestFile(string name, string projectName, string source)
+        public TestFile(string? name, string projectName, string source)
             : this(name, projectName, source, Enumerable.Empty<string>())
         {
         }
 
-        public TestFile(string name, string projectName, string source, IEnumerable<string> referencedProjectNames)
+        public TestFile(string? name, string projectName, string source, IEnumerable<string> referencedProjectNames)
         {
-            Name = name;
+            Name = name ?? "Test0.cs";
             ProjectName = projectName;
             Source = source;
             ReferencedProjectNames = referencedProjectNames;
@@ -49,7 +49,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.TestFiles
 
         public static bool operator !=(TestFile left, TestFile right) => !(left == right);
 
-        public override bool Equals(object obj) => !(obj is TestFile) ? false : Equals((TestFile)obj);
+        public override bool Equals(object obj) => obj is TestFile file && Equals(file);
 
         public override int GetHashCode()
         {

--- a/tests/NationalInstruments.Analyzers.TestUtilities/TestMarkup.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities/TestMarkup.cs
@@ -61,10 +61,10 @@ namespace NationalInstruments.Analyzers.TestUtilities
             if (!ContainsMarkers(markup))
             {
                 source = markup;
-                return null;
+                return new SourceMarker[] { };
             }
 
-            var markupBySpan = new Dictionary<TextSpan, Markup>();
+            var markupBySpan = new Dictionary<TextSpan, Markup?>();
 
             for (var i = 0; i < markup.Length - 1; ++i)
             {
@@ -131,7 +131,7 @@ namespace NationalInstruments.Analyzers.TestUtilities
             string markup,
             int index,
             PositionMarkupDefinition markupDefinition,
-            out PositionMarkup positionMarkup,
+            out PositionMarkup? positionMarkup,
             out TextSpan span)
         {
             var currentMarkup = markup.Substring(0, index + 1);
@@ -146,7 +146,7 @@ namespace NationalInstruments.Analyzers.TestUtilities
             }
 
             // Use defaults (values shouldn't be used)
-            span = default(TextSpan);
+            span = default;
             positionMarkup = null;
 
             return false;
@@ -156,7 +156,7 @@ namespace NationalInstruments.Analyzers.TestUtilities
             string markup,
             int index,
             CaptureMarkupDefinition markupDefinition,
-            out CaptureMarkup captureMarkup,
+            out CaptureMarkup? captureMarkup,
             out TextSpan startSpan,
             out TextSpan endSpan)
         {
@@ -191,8 +191,8 @@ namespace NationalInstruments.Analyzers.TestUtilities
             }
 
             // Use defaults (values shouldn't be used)
-            startSpan = default(TextSpan);
-            endSpan = default(TextSpan);
+            startSpan = default;
+            endSpan = default;
             captureMarkup = null;
 
             return false;
@@ -203,7 +203,7 @@ namespace NationalInstruments.Analyzers.TestUtilities
             return new TextSpan(i - (syntax.Length - 1), syntax.Length);
         }
 
-        private string GetSourceFromMarkup(string markup, Dictionary<TextSpan, Markup> markupBySpan)
+        private string GetSourceFromMarkup(string markup, Dictionary<TextSpan, Markup?> markupBySpan)
         {
             var removed = 0;
             var output = new StringBuilder(markup);
@@ -221,9 +221,8 @@ namespace NationalInstruments.Analyzers.TestUtilities
                 {
                     positionMarkup.Index -= removed;
                 }
-                else
+                else if (markupInstance is CaptureMarkup captureMarkup)
                 {
-                    var captureMarkup = (CaptureMarkup)markupInstance;
                     if (span.Start == captureMarkup.StartIndex)
                     {
                         captureMarkup.StartIndex -= removed;
@@ -240,11 +239,11 @@ namespace NationalInstruments.Analyzers.TestUtilities
             return output.ToString();
         }
 
-        private IEnumerable<SourceMarker> CreateSourceMarkers(IEnumerable<Markup> markups, string source)
+        private IEnumerable<SourceMarker> CreateSourceMarkers(IEnumerable<Markup?> markups, string source)
         {
             foreach (var markup in markups)
             {
-                switch (markup.Type)
+                switch (markup?.Type)
                 {
                     case MarkupType.Diagnostic:
                         if (markup is PositionMarkup positionMarkup)
@@ -279,7 +278,7 @@ namespace NationalInstruments.Analyzers.TestUtilities
                         break;
 
                     default:
-                        throw new InvalidOperationException($"Unknown markup type: {markup.Type}");
+                        throw new InvalidOperationException($"Unknown markup type: {markup?.Type}");
                 }
             }
         }

--- a/tests/NationalInstruments.Analyzers.TestUtilities/Verifiers/DiagnosticVerifier.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities/Verifiers/DiagnosticVerifier.cs
@@ -21,7 +21,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
         /// <summary>
         /// Get the CSharp analyzer being tested - to be implemented in non-abstract class
         /// </summary>
-        protected virtual DiagnosticAnalyzer DiagnosticAnalyzer => null;
+        protected virtual DiagnosticAnalyzer? DiagnosticAnalyzer => null;
 
         /// <summary>
         /// The test will verify that the diagnostic messages exactly match the expected messages if <c>true</c>.
@@ -44,21 +44,21 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
 
         /// <inheritdoc cref="VerifyDiagnostics(TestFile, DiagnosticResult[])"/>
         /// <param name="additionalFile">A supporting test file that will appear to the analyzer as an "additional file".</param>
-        protected IEnumerable<Diagnostic> VerifyDiagnostics(TestFile testFile, AdditionalText additionalFile, params DiagnosticResult[] expectedDiagnostics)
+        protected IEnumerable<Diagnostic> VerifyDiagnostics(TestFile testFile, AdditionalText? additionalFile, params DiagnosticResult[] expectedDiagnostics)
         {
-            return VerifyDiagnostics(testFile, new[] { additionalFile }.Where(x => x != null), expectedDiagnostics);
+            return VerifyDiagnostics(testFile, additionalFile is null ? null : new[] { additionalFile }, expectedDiagnostics);
         }
 
         /// <inheritdoc cref="VerifyDiagnostics(TestFile, DiagnosticResult[])"/>
         /// <param name="additionalFiles">Supporting test files that will appear to the analyzer as "additional files".</param>
-        protected IEnumerable<Diagnostic> VerifyDiagnostics(TestFile testFile, IEnumerable<AdditionalText> additionalFiles, params DiagnosticResult[] expectedDiagnostics)
+        protected IEnumerable<Diagnostic> VerifyDiagnostics(TestFile testFile, IEnumerable<AdditionalText>? additionalFiles, params DiagnosticResult[] expectedDiagnostics)
         {
             return VerifyDiagnostics(testFile, additionalFiles, null, expectedDiagnostics);
         }
 
         /// <inheritdoc cref="VerifyDiagnostics(TestFile, IEnumerable{AdditionalText}, DiagnosticResult[])"/>
         /// <param name="projectAdditionalFiles">Mapping of project names to the <see cref="AdditionalText"/> files they include.</param>
-        protected IEnumerable<Diagnostic> VerifyDiagnostics(TestFile testFile, IEnumerable<AdditionalText> additionalFiles, Dictionary<string, IEnumerable<AdditionalText>> projectAdditionalFiles, params DiagnosticResult[] expectedDiagnostics)
+        protected IEnumerable<Diagnostic> VerifyDiagnostics(TestFile testFile, IEnumerable<AdditionalText>? additionalFiles, Dictionary<string, IEnumerable<AdditionalText>>? projectAdditionalFiles, params DiagnosticResult[] expectedDiagnostics)
         {
             return VerifyDiagnostics(new[] { testFile }, additionalFiles, projectAdditionalFiles, expectedDiagnostics);
         }
@@ -72,21 +72,21 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
 
         /// <inheritdoc cref="VerifyDiagnostics(TestFile, AdditionalText, DiagnosticResult[])"/>
         /// <inheritdoc cref="VerifyDiagnostics(TestFile[], DiagnosticResult[])" path="param"/>
-        protected IEnumerable<Diagnostic> VerifyDiagnostics(TestFile[] testFiles, AdditionalText additionalFile, params DiagnosticResult[] expectedDiagnostics)
+        protected IEnumerable<Diagnostic> VerifyDiagnostics(TestFile[] testFiles, AdditionalText? additionalFile, params DiagnosticResult[] expectedDiagnostics)
         {
-            return VerifyDiagnostics(testFiles, new[] { additionalFile }.Where(x => x != null), expectedDiagnostics);
+            return VerifyDiagnostics(testFiles, additionalFile is null ? null : new[] { additionalFile }, expectedDiagnostics);
         }
 
         /// <inheritdoc cref="VerifyDiagnostics(TestFile, IEnumerable{AdditionalText}, DiagnosticResult[])"/>
         /// <inheritdoc cref="VerifyDiagnostics(TestFile[], DiagnosticResult[])" path="param"/>
-        protected IEnumerable<Diagnostic> VerifyDiagnostics(TestFile[] testFiles, IEnumerable<AdditionalText> additionalFiles, params DiagnosticResult[] expectedDiagnostics)
+        protected IEnumerable<Diagnostic> VerifyDiagnostics(TestFile[] testFiles, IEnumerable<AdditionalText>? additionalFiles, params DiagnosticResult[] expectedDiagnostics)
         {
             return VerifyDiagnostics(testFiles, additionalFiles, null, expectedDiagnostics);
         }
 
         /// <inheritdoc cref="VerifyDiagnostics(TestFile, IEnumerable{AdditionalText}, Dictionary{string, IEnumerable{AdditionalText}}, DiagnosticResult[])"/>
         /// <inheritdoc cref="VerifyDiagnostics(TestFile[], DiagnosticResult[])" path="param"/>
-        protected IEnumerable<Diagnostic> VerifyDiagnostics(TestFile[] testFiles, IEnumerable<AdditionalText> additionalFiles, Dictionary<string, IEnumerable<AdditionalText>> projectAdditionalFiles, params DiagnosticResult[] expectedDiagnostics)
+        protected IEnumerable<Diagnostic> VerifyDiagnostics(TestFile[] testFiles, IEnumerable<AdditionalText>? additionalFiles, Dictionary<string, IEnumerable<AdditionalText>>? projectAdditionalFiles, params DiagnosticResult[] expectedDiagnostics)
         {
             var context = new JoinableTaskContext();
             var diagnostics = new JoinableTaskFactory(context).Run(
@@ -101,42 +101,42 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
         /// <param name="testFile">A test file belonging to a project that may contain diagnostic markup.</param>
         /// <param name="additionalFile">A supporting test file that will appear to the analyzer as an "additional file".</param>
         /// <returns>The actual diagnostics.</returns>
-        protected IEnumerable<Diagnostic> VerifyDiagnostics(AutoTestFile testFile, AdditionalText additionalFile = null)
+        protected IEnumerable<Diagnostic> VerifyDiagnostics(AutoTestFile testFile, AdditionalText? additionalFile = null)
         {
-            return VerifyDiagnostics(testFile, new[] { additionalFile }.Where(x => x != null));
+            return VerifyDiagnostics(testFile, additionalFile is null ? null : new[] { additionalFile });
         }
 
         /// <inheritdoc cref="VerifyDiagnostics(AutoTestFile, AdditionalText)"/>
         /// <param name="additionalFiles">Supporting test files that will appear to the analyzer as "additional files".</param>
-        protected IEnumerable<Diagnostic> VerifyDiagnostics(AutoTestFile testFile, IEnumerable<AdditionalText> additionalFiles)
+        protected IEnumerable<Diagnostic> VerifyDiagnostics(AutoTestFile testFile, IEnumerable<AdditionalText>? additionalFiles)
         {
             return VerifyDiagnostics(testFile, additionalFiles, null);
         }
 
         /// <inheritdoc cref="VerifyDiagnostics(AutoTestFile, IEnumerable{AdditionalText})"/>
         /// <param name="projectAdditionalFiles">Mapping of project names to the <see cref="AdditionalText"/> files they include.</param>
-        protected IEnumerable<Diagnostic> VerifyDiagnostics(AutoTestFile testFile, IEnumerable<AdditionalText> additionalFiles, Dictionary<string, IEnumerable<AdditionalText>> projectAdditionalFiles)
+        protected IEnumerable<Diagnostic> VerifyDiagnostics(AutoTestFile testFile, IEnumerable<AdditionalText>? additionalFiles, Dictionary<string, IEnumerable<AdditionalText>>? projectAdditionalFiles)
         {
             return VerifyDiagnostics(new[] { testFile }, additionalFiles, projectAdditionalFiles);
         }
 
         /// <inheritdoc cref="VerifyDiagnostics(AutoTestFile, AdditionalText)"/>
         /// <param name="testFiles">Test files belonging to a project that may contain diagnostic markup.</param>
-        protected IEnumerable<Diagnostic> VerifyDiagnostics(AutoTestFile[] testFiles, AdditionalText additionalFile = null)
+        protected IEnumerable<Diagnostic> VerifyDiagnostics(AutoTestFile[] testFiles, AdditionalText? additionalFile = null)
         {
-            return VerifyDiagnostics(testFiles, new[] { additionalFile }.Where(x => x != null));
+            return VerifyDiagnostics(testFiles, additionalFile is null ? null : new[] { additionalFile });
         }
 
         /// <inheritdoc cref="VerifyDiagnostics(AutoTestFile, IEnumerable{AdditionalText})"/>
         /// <inheritdoc cref="VerifyDiagnostics(AutoTestFile[], AdditionalText)" path="param"/>
-        protected IEnumerable<Diagnostic> VerifyDiagnostics(AutoTestFile[] testFiles, IEnumerable<AdditionalText> additionalFiles)
+        protected IEnumerable<Diagnostic> VerifyDiagnostics(AutoTestFile[] testFiles, IEnumerable<AdditionalText>? additionalFiles)
         {
             return VerifyDiagnostics(testFiles, additionalFiles, null);
         }
 
         /// <inheritdoc cref="VerifyDiagnostics(AutoTestFile, IEnumerable{AdditionalText}, Dictionary{string, IEnumerable{AdditionalText}})"/>
         /// <inheritdoc cref="VerifyDiagnostics(AutoTestFile[], AdditionalText)" path="param"/>
-        protected IEnumerable<Diagnostic> VerifyDiagnostics(AutoTestFile[] testFiles, IEnumerable<AdditionalText> additionalFiles, Dictionary<string, IEnumerable<AdditionalText>> projectAdditionalFiles)
+        protected IEnumerable<Diagnostic> VerifyDiagnostics(AutoTestFile[] testFiles, IEnumerable<AdditionalText>? additionalFiles, Dictionary<string, IEnumerable<AdditionalText>>? projectAdditionalFiles)
         {
             var context = new JoinableTaskContext();
             var diagnostics = new JoinableTaskFactory(context).Run(
@@ -235,7 +235,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
                                     "Test base does not currently handle diagnostics in metadata locations. Diagnostic in metadata: {0}\r\n",
                                     diagnostics[i]));
 
-                            var resultMethodName = diagnostics[i].Location.SourceTree.FilePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) ?
+                            var resultMethodName = (diagnostics[i].Location.SourceTree?.FilePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) ?? true) ?
                                 "GetCSharpResultAt" :
                                 "GetBasicResultAt";
                             var linePosition = diagnostics[i].Location.GetLineSpan().StartLinePosition;
@@ -272,8 +272,13 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
         /// <param name="analyzer">The analyzer that was being run on the sources</param>
         /// <param name="expectedResults">Diagnostic Results that should have appeared in the code</param>
         /// <returns>The actual diagnostics.</returns>
-        private IEnumerable<Diagnostic> VerifyDiagnosticResults(IEnumerable<Diagnostic> actualResults, DiagnosticAnalyzer analyzer, DiagnosticResult[] expectedResults)
+        private IEnumerable<Diagnostic> VerifyDiagnosticResults(IEnumerable<Diagnostic> actualResults, DiagnosticAnalyzer? analyzer, DiagnosticResult[] expectedResults)
         {
+            if (analyzer is null)
+            {
+                throw new ArgumentNullException(nameof(analyzer));
+            }
+
             var expectedCount = expectedResults.Length;
             var actualCount = actualResults.Count();
 

--- a/tests/NationalInstruments.Analyzers.TestUtilities/Verifiers/Rule.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities/Verifiers/Rule.cs
@@ -10,10 +10,10 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
     /// </summary>
     public struct Rule : IEquatable<Rule>
     {
-        public Rule(DiagnosticDescriptor diagnosticDescriptor, params string[] arguments)
+        public Rule(DiagnosticDescriptor diagnosticDescriptor, params string?[] arguments)
         {
             DiagnosticDescriptor = diagnosticDescriptor;
-            Arguments = arguments.ToList();
+            Arguments = arguments.Where(x => x is not null).Select(x => x!).ToList();
         }
 
         /// <summary>
@@ -30,7 +30,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
 
         public static bool operator !=(Rule left, Rule right) => !(left == right);
 
-        public override bool Equals(object obj) => !(obj is Rule) ? false : Equals((Rule)obj);
+        public override bool Equals(object obj) => obj is not Rule ? false : Equals((Rule)obj);
 
         public override int GetHashCode()
         {

--- a/tests/NationalInstruments.Analyzers.UnitTests/ApprovedNamespaceAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/ApprovedNamespaceAnalyzerTests.cs
@@ -543,8 +543,8 @@ namespace <?>NationalInstruments.TestUtilities.SourceModel
                 XUnit.*";
 
             private readonly string _testFilesFolder;
-            private TestAdditionalDocument _approvedNamespacesDocument;
-            private TestAdditionalDocument _approvedTestNamespacesDocument;
+            private TestAdditionalDocument? _approvedNamespacesDocument;
+            private TestAdditionalDocument? _approvedTestNamespacesDocument;
 
             public TestState()
             {
@@ -584,25 +584,25 @@ namespace <?>NationalInstruments.TestUtilities.SourceModel
 
             public void AppendToApprovedNamespacesFile(string namespaceName)
             {
-                File.AppendAllLines(_approvedNamespacesDocument.Path, new[] { namespaceName });
+                File.AppendAllLines(_approvedNamespacesDocument?.Path, new[] { namespaceName });
             }
 
             public void AppendToApprovedTestNamespacesFile(string namespaceName)
             {
-                File.AppendAllLines(_approvedTestNamespacesDocument.Path, new[] { namespaceName });
+                File.AppendAllLines(_approvedTestNamespacesDocument?.Path, new[] { namespaceName });
             }
 
             public void AssertNamespaceExistsInApprovedNamespacesFile(string namespaceName)
             {
-                AssertNamespaceExistsInFile(_approvedNamespacesDocument.Path, namespaceName);
+                AssertNamespaceExistsInFile(_approvedNamespacesDocument?.Path, namespaceName);
             }
 
             public void AssertNamespaceExistsInApprovedTestNamespacesFile(string namespaceName)
             {
-                AssertNamespaceExistsInFile(_approvedTestNamespacesDocument.Path, namespaceName);
+                AssertNamespaceExistsInFile(_approvedTestNamespacesDocument?.Path, namespaceName);
             }
 
-            private void AssertNamespaceExistsInFile(string filePath, string namespaceName)
+            private void AssertNamespaceExistsInFile(string? filePath, string namespaceName)
             {
                 Assert.NotNull(File
                     .ReadAllLines(filePath)

--- a/tests/NationalInstruments.Analyzers.UnitTests/DatabaseColumnsShouldBeNullableAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/DatabaseColumnsShouldBeNullableAnalyzerTests.cs
@@ -55,7 +55,7 @@ class MyDbContext : DbContext
         [InlineData("Id")]
         [InlineData("MyDataModelId")]
         [InlineData("MyPk", "[Key]")]
-        public void NI0017_PrimaryKey_NoDiagnostic(string propertyName, string attribute = null)
+        public void NI0017_PrimaryKey_NoDiagnostic(string propertyName, string? attribute = null)
         {
             var test = new AutoTestFile(Setup + $@"
 class MyDataModel
@@ -73,7 +73,7 @@ class MyDataModel
         [InlineData("Nullable<DateTime>")]
         [InlineData("IEnumerable<DateTime>")]
         [InlineData("int", "[NotMapped]")]
-        public void NI0017_AcceptableTypes_NoDiagnostic(string type, string attribute = null)
+        public void NI0017_AcceptableTypes_NoDiagnostic(string type, string? attribute = null)
         {
             var test = new AutoTestFile(Setup + $@"
 class MyDataModel
@@ -89,7 +89,7 @@ class MyDataModel
         [Theory]
         [InlineData("int", "Int32")]
         [InlineData("DateTime")]
-        public void NI0017_ValueTypes_Diagnostic(string type, string typeDiagnostic = null)
+        public void NI0017_ValueTypes_Diagnostic(string type, string? typeDiagnostic = null)
         {
             var test = new AutoTestFile(
                 Setup + $@"

--- a/tests/NationalInstruments.Analyzers.UnitTests/DoNotUseBannedMethodsAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/DoNotUseBannedMethodsAnalyzerTests.cs
@@ -521,7 +521,7 @@ class Program
             return GetBannedMethodsFile(null, bannedMethods);
         }
 
-        private TestAdditionalDocument GetBannedMethodsFile(FileInfo fileInfo, params string[] bannedMethods)
+        private TestAdditionalDocument GetBannedMethodsFile(FileInfo? fileInfo, params string[] bannedMethods)
         {
             var xml = $@"
 <BannedMethods>
@@ -535,7 +535,7 @@ class Program
             return GetBannedMethodsFromXml(null, xml);
         }
 
-        private TestAdditionalDocument GetBannedMethodsFromXml(FileInfo fileInfo, string xml)
+        private TestAdditionalDocument GetBannedMethodsFromXml(FileInfo? fileInfo, string xml)
         {
             var defaultFileInfo = new FileInfo(ExampleBannedMethodsFileName);
 

--- a/tests/NationalInstruments.Analyzers.UnitTests/SpellingAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/SpellingAnalyzerTests.cs
@@ -390,10 +390,10 @@ class Program
                     "The 'word' start tag on line 6 position 14 does not match the end tag of 'Word'. Line 6, position 24."));
         }
 
-        private static AdditionalText CreateXmlDictionary(IEnumerable<string> recognizedWords, IEnumerable<string> unrecognizedWords = null) =>
+        private static AdditionalText CreateXmlDictionary(IEnumerable<string>? recognizedWords, IEnumerable<string>? unrecognizedWords = null) =>
             CreateXmlDictionary("CodeAnalysisDictionary.xml", recognizedWords, unrecognizedWords);
 
-        private static AdditionalText CreateXmlDictionary(string filename, IEnumerable<string> recognizedWords, IEnumerable<string> unrecognizedWords = null)
+        private static AdditionalText CreateXmlDictionary(string filename, IEnumerable<string>? recognizedWords, IEnumerable<string>? unrecognizedWords = null)
         {
             var contents = $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <Dictionary>
@@ -405,7 +405,7 @@ class Program
 
             return new TestAdditionalDocument(filename, contents);
 
-            string CreateXml(IEnumerable<string> words) =>
+            string CreateXml(IEnumerable<string>? words) =>
                 string.Join(Environment.NewLine, words?.Select(x => $"<Word>{x}</Word>") ?? Enumerable.Empty<string>());
         }
 

--- a/tests/NationalInstruments.Analyzers.UnitTests/StringsShouldBeInResourcesAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/StringsShouldBeInResourcesAnalyzerTests.cs
@@ -2392,7 +2392,7 @@ class Foo
             return GetExemptionsFile(null, exemptions);
         }
 
-        private TestAdditionalDocument GetExemptionsFile(FileInfo fileInfo, params string[] exemptions)
+        private TestAdditionalDocument GetExemptionsFile(FileInfo? fileInfo, params string[] exemptions)
         {
             var defaultFileInfo = new FileInfo(ExampleLiteralExemptionsFileName);
             var documentContents = $@"

--- a/tests/NationalInstruments.Analyzers.Utilities.UnitTests/AdditionalFileProviderTests.cs
+++ b/tests/NationalInstruments.Analyzers.Utilities.UnitTests/AdditionalFileProviderTests.cs
@@ -35,7 +35,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
             var file = fileProvider.GetFile("a.txt");
 
             Assert.NotNull(file);
-            Assert.Equal("a.txt", file.Path);
+            Assert.Equal("a.txt", file?.Path);
         }
 
         [Theory]
@@ -59,8 +59,8 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
             var file = fileProvider.GetFile("a.txt");
 
             Assert.NotNull(file);
-            Assert.Equal("a.txt", file.Path);
-            Assert.Equal("1", file.GetText().ToString());
+            Assert.Equal("a.txt", file?.Path);
+            Assert.Equal("1", file?.GetText()?.ToString());
         }
 
         [Theory]

--- a/tests/NationalInstruments.Analyzers.Utilities.UnitTests/AdditionalFileServiceTests.cs
+++ b/tests/NationalInstruments.Analyzers.Utilities.UnitTests/AdditionalFileServiceTests.cs
@@ -60,7 +60,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
             var parsedFile = additionalFileService.ParseXmlFile(additionalFile);
 
             Assert.Empty(additionalFileService.ParsingDiagnostics);
-            Assert.Equal(3, parsedFile.Elements("Entry").Count());
+            Assert.Equal(3, parsedFile?.Elements("Entry").Count());
         }
 
         [Fact]

--- a/tests/NationalInstruments.Analyzers.Utilities.UnitTests/ExemptionCollectionTests.cs
+++ b/tests/NationalInstruments.Analyzers.Utilities.UnitTests/ExemptionCollectionTests.cs
@@ -11,8 +11,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void Add_SingleValue_OneExemption()
         {
-            var exemptions = new ExemptionCollection();
-            exemptions.Add("foo");
+            var exemptions = new ExemptionCollection { "foo" };
 
             Assert.Single(exemptions);
         }
@@ -20,9 +19,11 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void Add_DuplicateValues_OneExemption()
         {
-            var exemptions = new ExemptionCollection();
-            exemptions.Add("foo");
-            exemptions.Add("foo");
+            var exemptions = new ExemptionCollection
+            {
+                "foo",
+                "foo"
+            };
 
             Assert.Single(exemptions);
         }
@@ -30,9 +31,11 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void Add_DuplicateValues_MixedCase_OneExemption()
         {
-            var exemptions = new ExemptionCollection();
-            exemptions.Add("foo");
-            exemptions.Add("FOO");
+            var exemptions = new ExemptionCollection
+            {
+                "foo",
+                "FOO"
+            };
 
             Assert.Single(exemptions);
         }
@@ -40,9 +43,11 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void Add_DuplicateValues_DuplicateAttributes_OneExemptionWithOneAttribute()
         {
-            var exemptions = new ExemptionCollection();
-            exemptions.Add("foo", new AttributeCollection(Tuple.Create("Assembly", "A")));
-            exemptions.Add("foo", new AttributeCollection(Tuple.Create("Assembly", "A")));
+            var exemptions = new ExemptionCollection
+            {
+                { "foo", new AttributeCollection(Tuple.Create("Assembly", "A")) },
+                { "foo", new AttributeCollection(Tuple.Create("Assembly", "A")) }
+            };
 
             Assert.Single(exemptions);
             Assert.Single(exemptions["foo"]);
@@ -51,35 +56,39 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void Add_DuplicateValues_DistinctAttributeNames_OneExemptionWithOneAttribute()
         {
-            var exemptions = new ExemptionCollection();
-            exemptions.Add("foo", new AttributeCollection(Tuple.Create("Assembly", "A")));
-            exemptions.Add("foo", new AttributeCollection(Tuple.Create("Parameter", "B")));
+            var exemptions = new ExemptionCollection
+            {
+                { "foo", new AttributeCollection(Tuple.Create("Assembly", "A")) },
+                { "foo", new AttributeCollection(Tuple.Create("Parameter", "B")) }
+            };
 
             var attributes = exemptions["foo"];
 
             Assert.Single(exemptions);
             Assert.Single(attributes);
 
-            Assert.DoesNotContain("Assembly", attributes.Names);
-            Assert.Contains("Parameter", attributes.Names);
-            Assert.Single(attributes["Parameter"]);
+            Assert.DoesNotContain("Assembly", attributes?.Names);
+            Assert.Contains("Parameter", attributes?.Names);
+            Assert.Single(attributes?["Parameter"]);
         }
 
         [Fact]
         public void Add_DuplicateValues_DistinctAttributeValues_OneExemptionWithOneCombinedAttribute()
         {
-            var exemptions = new ExemptionCollection();
-            exemptions.Add("foo", new AttributeCollection(Tuple.Create("Assembly", "A")));
-            exemptions.Add("foo", new AttributeCollection(Tuple.Create("Assembly", "B")));
+            var exemptions = new ExemptionCollection
+            {
+                { "foo", new AttributeCollection(Tuple.Create("Assembly", "A")) },
+                { "foo", new AttributeCollection(Tuple.Create("Assembly", "B")) }
+            };
 
             var attributes = exemptions["foo"];
 
             Assert.Single(exemptions);
             Assert.Single(attributes);
 
-            Assert.Contains("Assembly", attributes.Names);
+            Assert.Contains("Assembly", attributes?.Names);
 
-            var attributeValues = attributes["Assembly"];
+            var attributeValues = attributes?["Assembly"];
             Assert.Contains("A", attributeValues);
             Assert.Contains("B", attributeValues);
         }
@@ -88,9 +97,11 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         public void Add_DistinctValues_MultipleExemptions()
         {
             const int ExpectedCount = 2;
-            var exemptions = new ExemptionCollection();
-            exemptions.Add("foo");
-            exemptions.Add("bar");
+            var exemptions = new ExemptionCollection
+            {
+                "foo",
+                "bar"
+            };
 
             Assert.Equal(ExpectedCount, exemptions.Count);
         }
@@ -124,7 +135,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [InlineData("Parameter", "A")]
         public void Contains_WithAttribute_WrongAttributeSpecified_NotFound(string name, string value)
         {
-            var exemption = Tuple.Create("foo", new AttributeCollection(Tuple.Create("Assembly", "A")));
+            var exemption = Tuple.Create<string, AttributeCollection?>("foo", new AttributeCollection(Tuple.Create("Assembly", "A")));
             var exemptions = new ExemptionCollection(exemption);
 
             Assert.False(exemptions.Contains("foo", new AttributeCollection(Tuple.Create(name, value))));
@@ -133,7 +144,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void Contains_WithAttribute_AttributeSpecified_Found()
         {
-            var exemption = Tuple.Create("foo", new AttributeCollection(Tuple.Create("Assembly", "A")));
+            var exemption = Tuple.Create<string, AttributeCollection?>("foo", new AttributeCollection(Tuple.Create("Assembly", "A")));
             var exemptions = new ExemptionCollection(exemption);
 
             Assert.True(exemptions.Contains("foo", new AttributeCollection(Tuple.Create("Assembly", "A"))));
@@ -142,7 +153,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void Contains_WithAttribute_LessAttributesSpecified_NotFound()
         {
-            var exemption = Tuple.Create("foo", new AttributeCollection(Tuple.Create("Assembly", "A")));
+            var exemption = Tuple.Create<string, AttributeCollection?>("foo", new AttributeCollection(Tuple.Create("Assembly", "A")));
             var exemptions = new ExemptionCollection(exemption);
 
             Assert.False(exemptions.Contains("foo"));
@@ -151,7 +162,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void Contains_WithAttribute_MoreAttributesSpecified_Found()
         {
-            var exemption = Tuple.Create("foo", new AttributeCollection(Tuple.Create("Assembly", "A")));
+            var exemption = Tuple.Create<string, AttributeCollection?>("foo", new AttributeCollection(Tuple.Create("Assembly", "A")));
             var exemptions = new ExemptionCollection(exemption);
 
             Assert.True(exemptions.Contains("foo", new AttributeCollection(Tuple.Create("Assembly", "A"), Tuple.Create("Parameter", "B"))));
@@ -162,7 +173,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [InlineData("Namespace", "A", "Scope", "B")]
         public void Contains_WithAttributes_WrongAttributesSpecified_NotFound(string name1, string value1, string name2, string value2)
         {
-            var exemption = Tuple.Create("foo", new AttributeCollection(Tuple.Create("Assembly", "A"), Tuple.Create("Parameter", "B")));
+            var exemption = Tuple.Create<string, AttributeCollection?>("foo", new AttributeCollection(Tuple.Create("Assembly", "A"), Tuple.Create("Parameter", "B")));
             var exemptions = new ExemptionCollection(exemption);
 
             Assert.False(exemptions.Contains("foo", new AttributeCollection(Tuple.Create(name1, value1), Tuple.Create(name2, value2))));
@@ -171,7 +182,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void Contains_WithAttributes_AllAttributesSpecified_Found()
         {
-            var exemption = Tuple.Create("foo", new AttributeCollection(Tuple.Create("Assembly", "A"), Tuple.Create("Parameter", "B")));
+            var exemption = Tuple.Create<string, AttributeCollection?>("foo", new AttributeCollection(Tuple.Create("Assembly", "A"), Tuple.Create("Parameter", "B")));
             var exemptions = new ExemptionCollection(exemption);
 
             Assert.True(exemptions.Contains("foo", new AttributeCollection(Tuple.Create("Assembly", "A"), Tuple.Create("Parameter", "B"))));
@@ -181,7 +192,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void Contains_WithAttributes_LessAttributesSpecified_NotFound()
         {
-            var exemption = Tuple.Create("foo", new AttributeCollection(Tuple.Create("Assembly", "A"), Tuple.Create("Parameter", "B")));
+            var exemption = Tuple.Create<string, AttributeCollection?>("foo", new AttributeCollection(Tuple.Create("Assembly", "A"), Tuple.Create("Parameter", "B")));
             var exemptions = new ExemptionCollection(exemption);
 
             Assert.False(exemptions.Contains("foo", new AttributeCollection(Tuple.Create("Assembly", "A"))));
@@ -190,7 +201,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void Contains_WithAttributes_MoreAttributesSpecified_Found()
         {
-            var exemption = Tuple.Create("foo", new AttributeCollection(Tuple.Create("Assembly", "A"), Tuple.Create("Parameter", "B")));
+            var exemption = Tuple.Create<string, AttributeCollection?>("foo", new AttributeCollection(Tuple.Create("Assembly", "A"), Tuple.Create("Parameter", "B")));
             var exemptions = new ExemptionCollection(exemption);
 
             Assert.True(exemptions.Contains("foo", new AttributeCollection(Tuple.Create("Assembly", "A"), Tuple.Create("Parameter", "B"), Tuple.Create("Namespace", "C"))));
@@ -199,7 +210,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void Contains_WithMultiValuedAttribute_ValueNotSpecified_Found()
         {
-            var exemptions = new ExemptionCollection(Tuple.Create("foo", new AttributeCollection(Tuple.Create("Assembly", "A|B"))));
+            var exemptions = new ExemptionCollection(Tuple.Create<string, AttributeCollection?>("foo", new AttributeCollection(Tuple.Create("Assembly", "A|B"))));
 
             Assert.True(exemptions.Contains("foo", new AttributeCollection(Tuple.Create("Assembly", "A"))));
         }
@@ -207,7 +218,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void Contains_WithMultiValuedAttribute_WrongValueSpecified_NotFound()
         {
-            var exemptions = new ExemptionCollection(Tuple.Create("foo", new AttributeCollection(Tuple.Create("Assembly", "A|B"))));
+            var exemptions = new ExemptionCollection(Tuple.Create<string, AttributeCollection?>("foo", new AttributeCollection(Tuple.Create("Assembly", "A|B"))));
 
             Assert.False(exemptions.Contains("foo", new AttributeCollection(Tuple.Create("Assembly", "D"))));
         }
@@ -230,7 +241,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void Matches_WithAttribute_AttributeSpecified_Found()
         {
-            var exemptions = new ExemptionCollection(Tuple.Create("*", new AttributeCollection(Tuple.Create("Assembly", "A"))));
+            var exemptions = new ExemptionCollection(Tuple.Create<string, AttributeCollection?>("*", new AttributeCollection(Tuple.Create("Assembly", "A"))));
 
             Assert.True(exemptions.Matches("foo", new AttributeCollection(Tuple.Create("Assembly", "A"))));
         }
@@ -238,7 +249,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void Matches_WithAttribute_LessAttributesSpecified_NotFound()
         {
-            var exemptions = new ExemptionCollection(Tuple.Create("*", new AttributeCollection(Tuple.Create("Assembly", "A"))));
+            var exemptions = new ExemptionCollection(Tuple.Create<string, AttributeCollection?>("*", new AttributeCollection(Tuple.Create("Assembly", "A"))));
 
             Assert.False(exemptions.Matches("foo"));
         }
@@ -246,7 +257,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void Matches_WithAttribute_MoreAttributesSpecified_Found()
         {
-            var exemptions = new ExemptionCollection(Tuple.Create("*", new AttributeCollection(Tuple.Create("Assembly", "A"))));
+            var exemptions = new ExemptionCollection(Tuple.Create<string, AttributeCollection?>("*", new AttributeCollection(Tuple.Create("Assembly", "A"))));
 
             Assert.True(exemptions.Matches("foo", new AttributeCollection(Tuple.Create("Assembly", "A"), Tuple.Create("Parameter", "B"))));
         }

--- a/tests/NationalInstruments.Analyzers.Utilities.UnitTests/IEnumerableExtensionTests.cs
+++ b/tests/NationalInstruments.Analyzers.Utilities.UnitTests/IEnumerableExtensionTests.cs
@@ -28,7 +28,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
         [Fact]
         public void ToSafeEnumerable_NullEnumerable_IsNonNullAndEmpty()
         {
-            IEnumerable<int> nullEnumerable = null;
+            IEnumerable<int>? nullEnumerable = null;
             Assert.NotNull(nullEnumerable.ToSafeEnumerable());
             Assert.Empty(nullEnumerable.ToSafeEnumerable());
         }

--- a/tests/NationalInstruments.Analyzers.Utilities.UnitTests/ISymbolExtensionTests.cs
+++ b/tests/NationalInstruments.Analyzers.Utilities.UnitTests/ISymbolExtensionTests.cs
@@ -223,13 +223,13 @@ namespace My.Namespace
                 (tree, compilation) =>
                 {
                     var symbol = GetSymbol<PropertyDeclarationSyntax>(tree, compilation);
-                    Assert.Equal(ExpectedPropertyName, symbol.GetFullName());
+                    Assert.Equal(ExpectedPropertyName, symbol?.GetFullName());
 
                     var property = symbol as IPropertySymbol;
 
                     Assert.NotNull(property);
-                    Assert.Equal(ExpectedPropertyGetName, property.GetMethod.GetFullName());
-                    Assert.Equal(ExpectedPropertySetName, property.SetMethod.GetFullName());
+                    Assert.Equal(ExpectedPropertyGetName, property?.GetMethod?.GetFullName());
+                    Assert.Equal(ExpectedPropertySetName, property?.SetMethod?.GetFullName());
                 });
         }
 
@@ -258,13 +258,13 @@ namespace My.Namespace
                 (tree, compilation) =>
                 {
                     var symbol = GetSymbol<IndexerDeclarationSyntax>(tree, compilation);
-                    Assert.Equal(ExpectedIndexerName, symbol.GetFullName());
+                    Assert.Equal(ExpectedIndexerName, symbol?.GetFullName());
 
                     var property = symbol as IPropertySymbol;
 
                     Assert.NotNull(property);
-                    Assert.Equal(ExpectedIndexerGetName, property.GetMethod.GetFullName());
-                    Assert.Equal(ExpectedIndexerSetName, property.SetMethod.GetFullName());
+                    Assert.Equal(ExpectedIndexerGetName, property?.GetMethod?.GetFullName());
+                    Assert.Equal(ExpectedIndexerSetName, property?.SetMethod?.GetFullName());
                 });
         }
 
@@ -354,10 +354,10 @@ namespace My.Namespace
         {
             var symbol = GetSymbol<TSyntax>(tree, compilation);
 
-            Assert.Equal(expectedName, symbol.GetFullName());
+            Assert.Equal(expectedName, symbol?.GetFullName());
         }
 
-        private ISymbol GetSymbol<TSyntax>(SyntaxTree tree, Compilation compilation)
+        private ISymbol? GetSymbol<TSyntax>(SyntaxTree tree, Compilation compilation)
             where TSyntax : SyntaxNode
         {
             var semanticModel = compilation.GetSemanticModel(tree);

--- a/tests/NationalInstruments.Analyzers.Utilities.UnitTests/ITypeSymbolExtensionTests.cs
+++ b/tests/NationalInstruments.Analyzers.Utilities.UnitTests/ITypeSymbolExtensionTests.cs
@@ -74,7 +74,7 @@ class Foo
                     var method = methodSyntax.GetDeclaredOrReferencedSymbol(compilation.GetSemanticModel(tree));
 
                     var i = 0;
-                    foreach (ITypeSymbol type in method.ContainingType.GetBaseTypesAndThis())
+                    foreach (var type in (method?.ContainingType?.GetBaseTypesAndThis()).ToSafeEnumerable())
                     {
                         Assert.Equal(expectedTypes[i++], type.Name);
                     }

--- a/tests/NationalInstruments.Analyzers.Utilities.UnitTests/SourceTextExtensionTests.cs
+++ b/tests/NationalInstruments.Analyzers.Utilities.UnitTests/SourceTextExtensionTests.cs
@@ -11,19 +11,13 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
     public sealed class SourceTextExtensionTests
     {
         [Fact]
-        public void NullSourceText_Parse_Throws()
-        {
-            SourceText sourceText = null;
-
-            Assert.Throws<ArgumentNullException>("text", () => sourceText.Parse(stream => stream.ReadToEnd()));
-        }
-
-        [Fact]
         public void SourceText_ParseWithNullFunction_Throws()
         {
             var sourceText = SourceText.From(string.Empty);
 
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             Assert.Throws<ArgumentNullException>("parser", () => sourceText.Parse<int>(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         }
 
         [Fact]

--- a/tests/NationalInstruments.Analyzers.Utilities.UnitTests/StringExtensionTests.cs
+++ b/tests/NationalInstruments.Analyzers.Utilities.UnitTests/StringExtensionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Windows.Interop;
 using NationalInstruments.Analyzers.Utilities.Extensions;
 using Xunit;
 
@@ -45,10 +46,12 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
             Assert.Throws<ArgumentNullException>(() => ExampleText.MatchesWildcardPattern(null));
         }
 
-        [Fact]
-        public void MatchesWildcardPattern_InputNull_ThrowsArgumentNullException()
+        [Theory]
+        [InlineData(false)]
+        public void MatchesWildcardPattern_InputNull_ThrowsArgumentNullException(bool argument)
         {
-            Assert.Throws<ArgumentNullException>(() => ((string)null).MatchesWildcardPattern("Anything"));
+            var input = argument ? string.Empty : null;
+            Assert.Throws<ArgumentNullException>(() => input.MatchesWildcardPattern("Anything"));
         }
     }
 }


### PR DESCRIPTION
# Justification
["All project templates starting with .NET 6 (C# 10) enable the nullable context for the project."](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/nullable-reference-types). This change enables nullable reference types as they're the future and they make code more explicit.

# Implementation
Enabled `nullable`, fixed warnings, and updated visible usages of `var == null` / `var != null` to `var is null` / `var is not null`

# Testing
Existing tests pass