### PR TITLE
Fix markup when syntax is at extremes

### DIFF
--- a/tests/NationalInstruments.Analyzers.TestUtilities.UnitTests/TestMarkupTests.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities.UnitTests/TestMarkupTests.cs
@@ -341,5 +341,17 @@ namespace My.Namespace
 
             Assert.Throws<InvalidOperationException>(() => new TestMarkup().Parse(test, out var source));
         }
+
+        [Fact]
+        public void ExtremesDiagnosticTextSyntax_TextCaptured()
+        {
+            const int ExpectedMarkerCount = 1;
+            const string Test = @"<|class Program { }|>";
+
+            var markers = new TestMarkup().Parse(Test, out var source);
+
+            Assert.NotNull(markers);
+            Assert.Equal(ExpectedMarkerCount, markers.Count);
+        }
     }
 }

--- a/tests/NationalInstruments.Analyzers.TestUtilities/TestMarkup.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities/TestMarkup.cs
@@ -66,7 +66,7 @@ namespace NationalInstruments.Analyzers.TestUtilities
 
             var markupBySpan = new Dictionary<TextSpan, Markup?>();
 
-            for (var i = 0; i < markup.Length - 1; ++i)
+            for (var i = 0; i < markup.Length; ++i)
             {
                 // Look for markup that captures a position
                 foreach (var markupDefinition in PositionMarkupDefinitions)
@@ -95,7 +95,7 @@ namespace NationalInstruments.Analyzers.TestUtilities
                         markupBySpan.Add(endSpan, captureMarkup);
                     }
 
-                    if (i == markup.Length - 2)
+                    if (i == markup.Length - 1)
                     {
                         // We're at the very last character of the markup; do we have any unclosed instances of capture markup?
                         if (markupDefinition.StartSpans.Count > 0)


### PR DESCRIPTION
# Justification
The test added in this PR failed prior to the changes (markup syntax needs to capture the entire source text).

# Implementation
Adjusted the for loop to see all the characters.

# Testing
Added a test that previously failed and now passes