### PR TITLE
Switch to Nuget Central Package Management

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -57,10 +57,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32" />
-        <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" />
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" />
+        <PackageReference Include="StyleCop.Analyzers.Unstable" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,28 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally Condition="'$(ManagePackageVersionsCentrally)' == ''">true</ManagePackageVersionsCentrally>
+
+    <!-- Indicates that a rebuild is required if this file changes. -->
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <ItemGroup Label="Global package reference versions">
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32" />
+    <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />
+  </ItemGroup>
+
+  <ItemGroup Label="Global test package reference versions">
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageVersion Include="xunit" Version="2.4.1" />
+    <PackageVersion Include="xunit.assert" Version="2.4.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />
+  </ItemGroup>
+
+  <ItemGroup Label="Global NuGet Package Versions">
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.TestPlatform" Version="14.0.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="16.0.102" />
+  </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ManagePackageVersionsCentrally Condition="'$(ManagePackageVersionsCentrally)' == ''">true</ManagePackageVersionsCentrally>
-    <!-- Indicates that a rebuild is required if this file changes. -->
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,28 +1,20 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ManagePackageVersionsCentrally Condition="'$(ManagePackageVersionsCentrally)' == ''">true</ManagePackageVersionsCentrally>
-
     <!-- Indicates that a rebuild is required if this file changes. -->
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
-
-  <ItemGroup Label="Global package reference versions">
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
+  <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32" />
-    <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />
-  </ItemGroup>
-
-  <ItemGroup Label="Global test package reference versions">
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
-    <PackageVersion Include="xunit" Version="2.4.1" />
-    <PackageVersion Include="xunit.assert" Version="2.4.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />
-  </ItemGroup>
-
-  <ItemGroup Label="Global NuGet Package Versions">
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.2.0" />
     <PackageVersion Include="Microsoft.VisualStudio.TestPlatform" Version="14.0.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="16.0.102" />
+    <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />
+    <PackageVersion Include="xunit.assert" Version="2.4.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageVersion Include="xunit" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/src/NationalInstruments.Analyzers.Utilities/NationalInstruments.Analyzers.Utilities.csproj
+++ b/src/NationalInstruments.Analyzers.Utilities/NationalInstruments.Analyzers.Utilities.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
   </ItemGroup>
 
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>
 
   <Target Name="CopyTestFiles" AfterTargets="Build">

--- a/tests/NationalInstruments.Analyzers.TestUtilities.UnitTests/NationalInstruments.Analyzers.TestUtilities.UnitTests.csproj
+++ b/tests/NationalInstruments.Analyzers.TestUtilities.UnitTests/NationalInstruments.Analyzers.TestUtilities.UnitTests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/NationalInstruments.Analyzers.TestUtilities/NationalInstruments.Analyzers.TestUtilities.csproj
+++ b/tests/NationalInstruments.Analyzers.TestUtilities/NationalInstruments.Analyzers.TestUtilities.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.TestPlatform" Version="14.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.0.102" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.assert" Version="2.4.1" />
+    <PackageReference Include="Microsoft.VisualStudio.TestPlatform" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.assert" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/NationalInstruments.Analyzers.UnitTests/NationalInstruments.Analyzers.UnitTests.csproj
+++ b/tests/NationalInstruments.Analyzers.UnitTests/NationalInstruments.Analyzers.UnitTests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/NationalInstruments.Analyzers.Utilities.UnitTests/NationalInstruments.Analyzers.Utilities.UnitTests.csproj
+++ b/tests/NationalInstruments.Analyzers.Utilities.UnitTests/NationalInstruments.Analyzers.Utilities.UnitTests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.0.102" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
# Justification
Since .NET 6.0.300, there is a new [Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management) (CPM) feature that allows tracking nuget versions centrally. CPM relies on a new `Directory.Packages.props` file to maintain the list of nuget package versions and by default all projects cannot specify nuget versions—the build will break otherwise.

We should switch to using CPM to help simplify our build management, and ensure that all projects are using the same nuget package versions—switching to CPM will also make updating nuget packages in the future a lot easier.

# Implementation

- Extract all package reference versions to `Directory.Packages.props`.
- Remove version specifications in the original `<PackageReference` elements.

# Testing
Continues to build.