### PR TITLE
Update code analysis and xunit nuget versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,16 +3,16 @@
     <ManagePackageVersionsCentrally Condition="'$(ManagePackageVersionsCentrally)' == ''">true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.9.2" />
     <PackageVersion Include="Microsoft.VisualStudio.TestPlatform" Version="14.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="16.0.102" />
     <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />
-    <PackageVersion Include="xunit.assert" Version="2.4.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageVersion Include="xunit" Version="2.4.1" />
+    <PackageVersion Include="xunit.assert" Version="2.7.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
+    <PackageVersion Include="xunit" Version="2.7.0" />
   </ItemGroup>
 </Project>

--- a/src/NationalInstruments.Analyzers/Correctness/ApprovedNamespaceAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/ApprovedNamespaceAnalyzer.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
@@ -21,8 +20,8 @@ namespace NationalInstruments.Analyzers.Correctness
     {
         internal const string DiagnosticId = "NI1800";
 
-        private static readonly Regex _testNamespacePattern = new Regex(@".+(\.Tests|\.TestUtilities)");
-        private static readonly SourceTextValueProvider<ApprovedNamespaces> _approvedNamespacesProvider = new SourceTextValueProvider<ApprovedNamespaces>(s => new ApprovedNamespaces(s));
+        private static readonly Regex _testNamespacePattern = new(@".+(\.Tests|\.TestUtilities)");
+        private static readonly SourceTextValueProvider<ApprovedNamespaces> _approvedNamespacesProvider = new(s => new ApprovedNamespaces(s));
 
         private ApprovedNamespaces? _approvedNamespaces;
         private ApprovedNamespaces? _approvedTestNamespaces;
@@ -30,7 +29,7 @@ namespace NationalInstruments.Analyzers.Correctness
         /// <summary>
         /// Rule for namespaces in production code
         /// </summary>
-        public static readonly DiagnosticDescriptor ProductionRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor ProductionRule = new(
             DiagnosticId,
             new LocalizableResourceString(nameof(Resources.NI1800_Title), Resources.ResourceManager, typeof(Resources)),
             new LocalizableResourceString(nameof(Resources.NI1800_Message), Resources.ResourceManager, typeof(Resources)),
@@ -43,7 +42,7 @@ namespace NationalInstruments.Analyzers.Correctness
         /// <summary>
         /// Rule for namespaces in test/testutilities code
         /// </summary>
-        public static readonly DiagnosticDescriptor TestRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor TestRule = new(
             DiagnosticId,
             new LocalizableResourceString(nameof(Resources.NI1800_TestTitle), Resources.ResourceManager, typeof(Resources)),
             new LocalizableResourceString(nameof(Resources.NI1800_TestMessage), Resources.ResourceManager, typeof(Resources)),
@@ -56,24 +55,26 @@ namespace NationalInstruments.Analyzers.Correctness
         /// <summary>
         /// Rule for failure to read approved namespaces files.
         /// </summary>
-        public static readonly DiagnosticDescriptor FileReadRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor FileReadRule = new(
             DiagnosticId,
             new LocalizableResourceString(nameof(Resources.NI1800_FileReadErrorTitle), Resources.ResourceManager, typeof(Resources)),
             new LocalizableResourceString(nameof(Resources.NI1800_FileReadErrorMessage), Resources.ResourceManager, typeof(Resources)),
             Category.Correctness,
             DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
+            isEnabledByDefault: true,
+            customTags: WellKnownDiagnosticTags.CompilationEnd);
 
         /// <summary>
         /// Rule for missing approved namespaces files.
         /// </summary>
-        public static readonly DiagnosticDescriptor MissingApprovalFilesRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor MissingApprovalFilesRule = new(
             DiagnosticId,
             new LocalizableResourceString(nameof(Resources.NI1800_MissingApprovalFilesErrorTitle), Resources.ResourceManager, typeof(Resources)),
             new LocalizableResourceString(nameof(Resources.NI1800_MissingApprovalFilesErrorMessage), Resources.ResourceManager, typeof(Resources)),
             Category.Correctness,
             DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
+            isEnabledByDefault: true,
+            customTags: WellKnownDiagnosticTags.CompilationEnd);
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(ProductionRule, TestRule, FileReadRule, MissingApprovalFilesRule);
@@ -214,8 +215,8 @@ namespace NationalInstruments.Analyzers.Correctness
         /// </summary>
         private class ApprovedNamespaces
         {
-            private readonly HashSet<string> _namespaces = new HashSet<string>();
-            private readonly List<Regex> _namespacePatterns = new List<Regex>();
+            private readonly HashSet<string> _namespaces = new();
+            private readonly List<Regex> _namespacePatterns = new();
 
             public ApprovedNamespaces(SourceText sourceText)
             {

--- a/src/NationalInstruments.Analyzers/Correctness/ApprovedNamespaceCodeFixProvider.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/ApprovedNamespaceCodeFixProvider.cs
@@ -1,7 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -84,6 +84,10 @@ namespace NationalInstruments.Analyzers.Correctness
                 return Task.FromResult(_context.Document);
             }
 
+            [SuppressMessage(
+                "MicrosoftCodeAnalysisCorrectness",
+                "RS1035:The symbol 'File' is banned for use by analyzers: Do not do file IO in analyzers",
+                Justification = "Existing working code.")]
             private void ApproveNamespace(string namespaceName, string namespacesFilePath)
             {
                 var lines = File.ReadAllLines(namespacesFilePath);

--- a/src/NationalInstruments.Analyzers/Correctness/AwaitInReadLockOrTransactionAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/AwaitInReadLockOrTransactionAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -16,7 +17,11 @@ namespace NationalInstruments.Analyzers.Correctness
     {
         internal const string DiagnosticId = "NI1015";
 
-        public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+        [SuppressMessage(
+            "MicrosoftCodeAnalysisCorrectness",
+            "RS1035:'CultureInfo.CurrentCulture' is banned for use by analyzers: Analyzers should use the locale given by the compiler command line arguments, not the CurrentCulture",
+            Justification = "No public API available to get the locale given to the compiler, see https://github.com/dotnet/roslyn/issues/66566")]
+        public static readonly DiagnosticDescriptor Rule = new(
             DiagnosticId,
             new LocalizableResourceString(nameof(Resources.NI1015_Title), Resources.ResourceManager, typeof(Resources)),
             new LocalizableResourceString(nameof(Resources.NI1015_Message), Resources.ResourceManager, typeof(Resources)),

--- a/src/NationalInstruments.Analyzers/Correctness/DoNotUseBannedMethodsAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/DoNotUseBannedMethodsAnalyzer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -50,7 +51,7 @@ namespace NationalInstruments.Analyzers.Correctness
 
         private static readonly LocalizableString LocalizedTitle = new LocalizableResourceString(nameof(Resources.NI1006_Title), Resources.ResourceManager, typeof(Resources));
 
-        public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor Rule = new(
             DiagnosticId,
             LocalizedTitle,
             new LocalizableResourceString(nameof(Resources.NI1006_Message), Resources.ResourceManager, typeof(Resources)),
@@ -60,7 +61,7 @@ namespace NationalInstruments.Analyzers.Correctness
             description: new LocalizableResourceString(nameof(Resources.NI1006_Description), Resources.ResourceManager, typeof(Resources)),
             helpLinkUri: "https://github.com/ni/csharp-styleguide/blob/main/docs/Banned%20Methods.md");
 
-        public static readonly DiagnosticDescriptor FileParseRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor FileParseRule = new(
             DiagnosticId,
             LocalizedTitle,
             new LocalizableResourceString(nameof(Resources.ParseError_Message), Resources.ResourceManager, typeof(Resources)),
@@ -93,7 +94,7 @@ namespace NationalInstruments.Analyzers.Correctness
         private class BannedMethodsAnalyzer : ConfigurableAnalyzer
         {
             private readonly IAdditionalFileService _additionalFileService;
-            private readonly HashSet<AnalyzerEntry> _bannedMethods = new HashSet<AnalyzerEntry>();
+            private readonly HashSet<AnalyzerEntry> _bannedMethods = new();
 
             public BannedMethodsAnalyzer(IAdditionalFileService additionalFileService, CancellationToken cancellationToken)
                 : base(additionalFileService, cancellationToken)
@@ -164,7 +165,7 @@ namespace NationalInstruments.Analyzers.Correctness
                 }
             }
 
-            private struct AnalyzerEntryOptionsForParsing
+            private readonly struct AnalyzerEntryOptionsForParsing
             {
                 private AnalyzerEntryOptionsForParsing(string justification, string alternative, string assemblies)
                 {
@@ -243,6 +244,10 @@ namespace NationalInstruments.Analyzers.Correctness
 
                 public IEnumerable<Regex> AssemblyRegexes { get; }
 
+                [SuppressMessage(
+                    "MicrosoftCodeAnalysisCorrectness",
+                    "RS1035:'CultureInfo.CurrentCulture' is banned for use by analyzers: Analyzers should use the locale given by the compiler command line arguments, not the CurrentCulture",
+                    Justification = "No public API available to get the locale given to the compiler, see https://github.com/dotnet/roslyn/issues/66566")]
                 public string AdditionalErrorMessage
                 {
                     get

--- a/src/NationalInstruments.Analyzers/Correctness/ReceiveWeakEventMustReturnTrueAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/ReceiveWeakEventMustReturnTrueAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -29,13 +30,17 @@ namespace NationalInstruments.Analyzers.Correctness
     /// }
     /// </example>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [SuppressMessage(
+        "MicrosoftCodeAnalysisCorrectness",
+        "RS1035:'CultureInfo.CurrentCulture' is banned for use by analyzers: Analyzers should use the locale given by the compiler command line arguments, not the CurrentCulture",
+        Justification = "No public API available to get the locale given to the compiler, see https://github.com/dotnet/roslyn/issues/66566")]
     public sealed class ReceiveWeakEventMustReturnTrueAnalyzer : NIDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "NI1005";
 
         private const string ReceiveWeakEventMethodName = "ReceiveWeakEvent";
 
-        public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor Rule = new(
             DiagnosticId,
             new LocalizableResourceString(nameof(Resources.NI1005_Title), Resources.ResourceManager, typeof(Resources)),
             new LocalizableResourceString(nameof(Resources.NI1005_Message), Resources.ResourceManager, typeof(Resources)),

--- a/src/NationalInstruments.Analyzers/Correctness/StringsShouldBeInResources/ExemptionAttribute.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/StringsShouldBeInResources/ExemptionAttribute.cs
@@ -52,6 +52,10 @@ namespace NationalInstruments.Analyzers.Correctness.StringsShouldBeInResources
             return GetTargetFromAttributeOrSymbol<ISymbol>(exemptionAttribute, null);
         }
 
+        [SuppressMessage(
+            "MicrosoftCodeAnalysisCorrectness",
+            "RS1035:'CultureInfo.CurrentCulture' is banned for use by analyzers: Analyzers should use the locale given by the compiler command line arguments, not the CurrentCulture",
+            Justification = "No public API available to get the locale given to the compiler, see https://github.com/dotnet/roslyn/issues/66566")]
         internal static string? GetTargetFromAttributeOrSymbol<TExpected>(ExemptionAttribute exemptionAttribute, ISymbol? decoratedSymbol)
         {
             if (!string.IsNullOrWhiteSpace(exemptionAttribute.Target))

--- a/src/NationalInstruments.Analyzers/Correctness/TestClassesMustInheritFromAutoTestAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Correctness/TestClassesMustInheritFromAutoTestAnalyzer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -32,6 +33,10 @@ namespace NationalInstruments.Analyzers.Correctness
     /// </code>
     /// </example>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [SuppressMessage(
+        "MicrosoftCodeAnalysisCorrectness",
+        "RS1035:'CultureInfo.CurrentCulture' is banned for use by analyzers: Analyzers should use the locale given by the compiler command line arguments, not the CurrentCulture",
+        Justification = "No public API available to get the locale given to the compiler, see https://github.com/dotnet/roslyn/issues/66566")]
     public class TestClassesMustInheritFromAutoTestAnalyzer : NIDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "NI1007";
@@ -39,7 +44,7 @@ namespace NationalInstruments.Analyzers.Correctness
         private const string TestClassAttributeTypeName = "Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute";
         private const string NIAutoTestAttributeTypeName = "NationalInstruments.Core.TestUtilities.AutoTest";
 
-        public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor Rule = new(
             DiagnosticId,
             new LocalizableResourceString(nameof(Resources.NI1007_Title), Resources.ResourceManager, typeof(Resources)),
             new LocalizableResourceString(nameof(Resources.NI1007_Message), Resources.ResourceManager, typeof(Resources)),

--- a/src/NationalInstruments.Analyzers/NationalInstruments.Analyzers.csproj
+++ b/src/NationalInstruments.Analyzers/NationalInstruments.Analyzers.csproj
@@ -5,6 +5,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <AssemblyName>NationalInstruments.Analyzers</AssemblyName>
     <RootNamespace>NationalInstruments.Analyzers</RootNamespace>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NationalInstruments.Analyzers/Style/FieldsCamelCasedWithUnderscoreCodeFixProvider.cs
+++ b/src/NationalInstruments.Analyzers/Style/FieldsCamelCasedWithUnderscoreCodeFixProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -62,6 +63,10 @@ namespace NationalInstruments.Analyzers.Style
             }
         }
 
+        [SuppressMessage(
+            "MicrosoftCodeAnalysisCorrectness",
+            "RS1035:'CultureInfo.CurrentCulture' is banned for use by analyzers: Analyzers should use the locale given by the compiler command line arguments, not the CurrentCulture",
+            Justification = "No public API available to get the locale given to the compiler, see https://github.com/dotnet/roslyn/issues/66566")]
         private static string FixName(string value)
         {
             var prefix = "_";

--- a/src/NationalInstruments.Analyzers/Style/SpellingAnalyzer.cs
+++ b/src/NationalInstruments.Analyzers/Style/SpellingAnalyzer.cs
@@ -32,15 +32,16 @@ namespace NationalInstruments.Analyzers.Style
         private static readonly SourceTextValueProvider<(CodeAnalysisDictionary? Dictionary, Exception? Exception)> _dicDictionaryProvider = new(text => ParseDictionary(text, isXml: false));
         private static readonly CodeAnalysisDictionary _mainDictionary = GetMainDictionary();
 
-        public static readonly DiagnosticDescriptor FileParseRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor FileParseRule = new(
             MisspelledDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_DictionaryParseError_Message)),
             Category.Style,
             DefaultDiagnosticSeverity,
-            isEnabledByDefault: true);
+            isEnabledByDefault: true,
+            customTags: WellKnownDiagnosticTags.CompilationEnd);
 
-        public static readonly DiagnosticDescriptor AssemblyRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor AssemblyRule = new(
             MisspelledDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_Assembly_Message)),
@@ -50,7 +51,7 @@ namespace NationalInstruments.Analyzers.Style
             description: LocalizableDescription,
             helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1704-identifiers-should-be-spelled-correctly");
 
-        public static readonly DiagnosticDescriptor NamespaceRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor NamespaceRule = new(
             MisspelledDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_Namespace_Message)),
@@ -60,7 +61,7 @@ namespace NationalInstruments.Analyzers.Style
             description: LocalizableDescription,
             helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1704-identifiers-should-be-spelled-correctly");
 
-        public static readonly DiagnosticDescriptor TypeRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor TypeRule = new(
             MisspelledDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_Type_Message)),
@@ -70,7 +71,7 @@ namespace NationalInstruments.Analyzers.Style
             description: LocalizableDescription,
             helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1704-identifiers-should-be-spelled-correctly");
 
-        public static readonly DiagnosticDescriptor MemberRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor MemberRule = new(
             MisspelledDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_Member_Message)),
@@ -80,7 +81,7 @@ namespace NationalInstruments.Analyzers.Style
             description: LocalizableDescription,
             helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1704-identifiers-should-be-spelled-correctly");
 
-        public static readonly DiagnosticDescriptor VariableRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor VariableRule = new(
             MisspelledDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_Variable_Message)),
@@ -89,7 +90,7 @@ namespace NationalInstruments.Analyzers.Style
             isEnabledByDefault: true,
             description: LocalizableDescription);
 
-        public static readonly DiagnosticDescriptor MemberParameterRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor MemberParameterRule = new(
             MisspelledDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_MemberParameter_Message)),
@@ -99,7 +100,7 @@ namespace NationalInstruments.Analyzers.Style
             description: LocalizableDescription,
             helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1704-identifiers-should-be-spelled-correctly");
 
-        public static readonly DiagnosticDescriptor DelegateParameterRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor DelegateParameterRule = new(
             MisspelledDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_DelegateParameter_Message)),
@@ -109,7 +110,7 @@ namespace NationalInstruments.Analyzers.Style
             description: LocalizableDescription,
             helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1704-identifiers-should-be-spelled-correctly");
 
-        public static readonly DiagnosticDescriptor TypeTypeParameterRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor TypeTypeParameterRule = new(
             MisspelledDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_TypeTypeParameter_Message)),
@@ -119,7 +120,7 @@ namespace NationalInstruments.Analyzers.Style
             description: LocalizableDescription,
             helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1704-identifiers-should-be-spelled-correctly");
 
-        public static readonly DiagnosticDescriptor MethodTypeParameterRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor MethodTypeParameterRule = new(
             MisspelledDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_MethodTypeParameter_Message)),
@@ -129,7 +130,7 @@ namespace NationalInstruments.Analyzers.Style
             description: LocalizableDescription,
             helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1704-identifiers-should-be-spelled-correctly");
 
-        public static readonly DiagnosticDescriptor AssemblyMoreMeaningfulNameRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor AssemblyMoreMeaningfulNameRule = new(
             UnmeaningfulDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_AssemblyMoreMeaningful_Message)),
@@ -139,7 +140,7 @@ namespace NationalInstruments.Analyzers.Style
             description: LocalizableDescription,
             helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1704-identifiers-should-be-spelled-correctly");
 
-        public static readonly DiagnosticDescriptor NamespaceMoreMeaningfulNameRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor NamespaceMoreMeaningfulNameRule = new(
             UnmeaningfulDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_NamespaceMoreMeaningful_Message)),
@@ -149,7 +150,7 @@ namespace NationalInstruments.Analyzers.Style
             description: LocalizableDescription,
             helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1704-identifiers-should-be-spelled-correctly");
 
-        public static readonly DiagnosticDescriptor TypeMoreMeaningfulNameRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor TypeMoreMeaningfulNameRule = new(
             UnmeaningfulDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_TypeMoreMeaningful_Message)),
@@ -159,7 +160,7 @@ namespace NationalInstruments.Analyzers.Style
             description: LocalizableDescription,
             helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1704-identifiers-should-be-spelled-correctly");
 
-        public static readonly DiagnosticDescriptor MemberMoreMeaningfulNameRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor MemberMoreMeaningfulNameRule = new(
             UnmeaningfulDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_MemberMoreMeaningful_Message)),
@@ -169,7 +170,7 @@ namespace NationalInstruments.Analyzers.Style
             description: LocalizableDescription,
             helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1704-identifiers-should-be-spelled-correctly");
 
-        public static readonly DiagnosticDescriptor MemberParameterMoreMeaningfulNameRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor MemberParameterMoreMeaningfulNameRule = new(
             UnmeaningfulDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_MemberParameterMoreMeaningful_Message)),
@@ -179,7 +180,7 @@ namespace NationalInstruments.Analyzers.Style
             description: LocalizableDescription,
             helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1704-identifiers-should-be-spelled-correctly");
 
-        public static readonly DiagnosticDescriptor DelegateParameterMoreMeaningfulNameRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor DelegateParameterMoreMeaningfulNameRule = new(
             UnmeaningfulDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_DelegateParameterMoreMeaningful_Message)),
@@ -189,7 +190,7 @@ namespace NationalInstruments.Analyzers.Style
             description: LocalizableDescription,
             helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1704-identifiers-should-be-spelled-correctly");
 
-        public static readonly DiagnosticDescriptor TypeTypeParameterMoreMeaningfulNameRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor TypeTypeParameterMoreMeaningfulNameRule = new(
             UnmeaningfulDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_TypeTypeParameterMoreMeaningful_Message)),
@@ -199,7 +200,7 @@ namespace NationalInstruments.Analyzers.Style
             description: LocalizableDescription,
             helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1704-identifiers-should-be-spelled-correctly");
 
-        public static readonly DiagnosticDescriptor MethodTypeParameterMoreMeaningfulNameRule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor MethodTypeParameterMoreMeaningfulNameRule = new(
             UnmeaningfulDiagnosticId,
             LocalizableTitle,
             CreateLocalizableResourceString(nameof(Resources.NI1704_MethodTypeParameterMoreMeaningful_Message)),

--- a/tests/NationalInstruments.Analyzers.TestUtilities.UnitTests/NationalInstruments.Analyzers.TestUtilities.UnitTests.csproj
+++ b/tests/NationalInstruments.Analyzers.TestUtilities.UnitTests/NationalInstruments.Analyzers.TestUtilities.UnitTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(NIAnalyzersTargetFramework)</TargetFramework>
     <AssemblyName>NationalInstruments.Analyzers.TestUtilities.UnitTests</AssemblyName>
     <RootNamespace>NationalInstruments.Analyzers.TestUtilities.UnitTests</RootNamespace>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/NationalInstruments.Analyzers.TestUtilities.UnitTests/TestMarkupTests.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities.UnitTests/TestMarkupTests.cs
@@ -61,11 +61,11 @@ namespace <|>My.Namespace
     }
 }";
 
-        private static readonly Test OneDiagnosticTextTest = new Test(
+        private static readonly Test OneDiagnosticTextTest = new(
             OneDiagnosticTextMarkup,
             new DiagnosticTextMarker(2, 11, "My.Namespace"));
 
-        private static readonly Test ManyDiagnosticTextsTest = new Test(
+        private static readonly Test ManyDiagnosticTextsTest = new(
             ManyDiagnosticTextsMarkup,
             new DiagnosticTextMarker(2, 11, "My.Namespace"),
             new DiagnosticTextMarker(4, 11, "Program"),
@@ -345,13 +345,12 @@ namespace My.Namespace
         [Fact]
         public void ExtremesDiagnosticTextSyntax_TextCaptured()
         {
-            const int ExpectedMarkerCount = 1;
             const string Test = @"<|class Program { }|>";
 
             var markers = new TestMarkup().Parse(Test, out var source);
 
             Assert.NotNull(markers);
-            Assert.Equal(ExpectedMarkerCount, markers.Count);
+            Assert.Single(markers);
         }
     }
 }

--- a/tests/NationalInstruments.Analyzers.TestUtilities/Verifiers/CodeFixVerifier.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities/Verifiers/CodeFixVerifier.cs
@@ -133,7 +133,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
                     }
                     newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, updatedCompilerDiagnostics);
 
-                    Assert.True(false, string.Format(
+                    Assert.Fail(string.Format(
                         CultureInfo.InvariantCulture,
                         "Fix introduced new compiler diagnostics:\r\n{0}\r\n\r\nNew document:\r\n{1}\r\n",
                         string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString())),

--- a/tests/NationalInstruments.Analyzers.TestUtilities/Verifiers/DiagnosticVerifier.Helper.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities/Verifiers/DiagnosticVerifier.Helper.cs
@@ -333,7 +333,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
                     }
                 }
 
-                Xunit.Assert.True(false, builder.ToString());
+                Xunit.Assert.Fail(builder.ToString());
             }
         }
 

--- a/tests/NationalInstruments.Analyzers.TestUtilities/Verifiers/DiagnosticVerifier.cs
+++ b/tests/NationalInstruments.Analyzers.TestUtilities/Verifiers/DiagnosticVerifier.cs
@@ -173,8 +173,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
             {
                 if (actualLinePosition.Line + 1 != expected.Line)
                 {
-                    Assert.True(
-                        false,
+                    Assert.Fail(
                         string.Format(
                             CultureInfo.InvariantCulture,
                             "Expected diagnostic to be on line \"{0}\" was actually on line \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
@@ -189,8 +188,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
             {
                 if (actualLinePosition.Character + 1 != expected.Column)
                 {
-                    Assert.True(
-                        false,
+                    Assert.Fail(
                         string.Format(
                             CultureInfo.InvariantCulture,
                             "Expected diagnostic to start at column \"{0}\" was actually at column \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
@@ -286,8 +284,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
             {
                 var diagnosticsOutput = actualResults.Any() ? FormatDiagnostics(analyzer, actualResults.ToArray()) : "    NONE.";
 
-                Assert.True(
-                    false,
+                Assert.Fail(
                     string.Format(
                         CultureInfo.InvariantCulture,
                         "Mismatch between number of diagnostics returned, expected \"{0}\" actual \"{1}\"\r\n\r\nDiagnostics:\r\n{2}\r\n",
@@ -305,8 +302,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
                 {
                     if (actual.Location != Location.None)
                     {
-                        Assert.True(
-                            false,
+                        Assert.Fail(
                             string.Format(
                                 CultureInfo.InvariantCulture,
                                 "Expected:\nA project diagnostic with No location\nActual:\n{0}",
@@ -320,8 +316,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
 
                     if (additionalLocations.Length != expected.Locations.Count - 1)
                     {
-                        Assert.True(
-                            false,
+                        Assert.Fail(
                             string.Format(
                                 CultureInfo.InvariantCulture,
                                 "Expected {0} additional locations but got {1} for Diagnostic:\r\n    {2}\r\n",
@@ -338,8 +333,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
 
                 if (actual.Id != expected.Id)
                 {
-                    Assert.True(
-                        false,
+                    Assert.Fail(
                         string.Format(
                             CultureInfo.InvariantCulture,
                             "Expected diagnostic id to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
@@ -350,8 +344,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
 
                 if (actual.Severity != expected.Severity)
                 {
-                    Assert.True(
-                        false,
+                    Assert.Fail(
                         string.Format(
                             CultureInfo.InvariantCulture,
                             "Expected diagnostic severity to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
@@ -364,8 +357,7 @@ namespace NationalInstruments.Analyzers.TestUtilities.Verifiers
                 {
                     if (actual.GetMessage() != expected.Message)
                     {
-                        Assert.True(
-                            false,
+                        Assert.Fail(
                             string.Format(
                                 CultureInfo.InvariantCulture,
                                 "Expected diagnostic message to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",

--- a/tests/NationalInstruments.Analyzers.UnitTests/StringsShouldBeInResourcesAnalyzerTests.cs
+++ b/tests/NationalInstruments.Analyzers.UnitTests/StringsShouldBeInResourcesAnalyzerTests.cs
@@ -1136,12 +1136,12 @@ partial class Program
         [InlineData(null, "element")]
         [InlineData(TestAssemblyName, null)]
         [InlineData(TestAssemblyName, "element")]
-        public void NI1004_StringLiteralInMethodInvocation_ExemptFromFile_AttributesMatch_NoDiagnostic(string assemblyName, string parameterName)
+        public void NI1004_StringLiteralInMethodInvocation_ExemptFromFile_AttributesMatch_NoDiagnostic(string? assemblyName, string? parameterName)
         {
             // Any method "type" could be used
             var test = new AutoTestFile(string.Format(CultureInfo.InvariantCulture, ExampleGenericMethodTestTemplate, ExampleLiteral, string.Empty));
 
-            var attributes = GetNonNullAttributesString(new Dictionary<string, string>
+            var attributes = GetNonNullAttributesString(new Dictionary<string, string?>
             {
                 ["Assembly"] = assemblyName,
                 ["Parameter"] = parameterName,
@@ -1154,14 +1154,14 @@ partial class Program
         [InlineData(null, "wrong")]
         [InlineData("Different", null)]
         [InlineData("Different", "wrong")]
-        public void NI1004_StringLiteralInMethodInvocation_ExemptFromFile_AttributesMismatch_Diagnostic(string assemblyName, string parameterName)
+        public void NI1004_StringLiteralInMethodInvocation_ExemptFromFile_AttributesMismatch_Diagnostic(string? assemblyName, string? parameterName)
         {
             // Any method "type" could be used
             var test = new AutoTestFile(
                 string.Format(CultureInfo.InvariantCulture, ExampleGenericMethodTestTemplate, ExampleLiteral, "<?>"),
                 GetNI1004LiteralRule(ExampleLiteral));
 
-            var attributes = GetNonNullAttributesString(new Dictionary<string, string>
+            var attributes = GetNonNullAttributesString(new Dictionary<string, string?>
             {
                 ["Assembly"] = assemblyName,
                 ["Parameter"] = parameterName,
@@ -1261,11 +1261,11 @@ class Program
         [InlineData(ExampleClassTestTemplate, "My.Namespace.ExemptClass", null, "name")]
         [InlineData(ExampleStructTestTemplate, "My.Namespace.ExemptStruct", TestAssemblyName, null)]
         [InlineData(ExampleAbstractClassTestTemplate, "My.Namespace.ExemptClassBase", TestAssemblyName, "name")]
-        public void NI1004_StringLiteralInMethodInvocation_TypeExemptFromFile_AttributesMatch_NoDiagnostic(string testTemplate, string exemption, string assemblyName, string parameterName)
+        public void NI1004_StringLiteralInMethodInvocation_TypeExemptFromFile_AttributesMatch_NoDiagnostic(string testTemplate, string exemption, string? assemblyName, string? parameterName)
         {
             var test = new AutoTestFile(string.Format(CultureInfo.InvariantCulture, testTemplate, ExampleLiteral, string.Empty));
 
-            var attributes = GetNonNullAttributesString(new Dictionary<string, string>
+            var attributes = GetNonNullAttributesString(new Dictionary<string, string?>
             {
                 ["Assembly"] = assemblyName,
                 ["Parameter"] = parameterName,
@@ -1278,13 +1278,13 @@ class Program
         [InlineData(ExampleClassTestTemplate, "My.Namespace.ExemptClass", null, "wrong")]
         [InlineData(ExampleStructTestTemplate, "My.Namespace.ExemptStruct", "Different", null)]
         [InlineData(ExampleAbstractClassTestTemplate, "My.Namespace.ExemptClassBase", "Different", "wrong")]
-        public void NI1004_StringLiteralInMethodInvocation_TypeExemptFromFile_AttributesMismatch_Diagnostic(string testTemplate, string exemption, string assemblyName, string parameterName)
+        public void NI1004_StringLiteralInMethodInvocation_TypeExemptFromFile_AttributesMismatch_Diagnostic(string testTemplate, string exemption, string? assemblyName, string? parameterName)
         {
             var test = new AutoTestFile(
                 string.Format(CultureInfo.InvariantCulture, testTemplate, ExampleLiteral, "<?>"),
                 GetNI1004LiteralRule(ExampleLiteral));
 
-            var attributes = GetNonNullAttributesString(new Dictionary<string, string>
+            var attributes = GetNonNullAttributesString(new Dictionary<string, string?>
             {
                 ["Assembly"] = assemblyName,
                 ["Parameter"] = parameterName,
@@ -1314,7 +1314,7 @@ class Program
         [InlineData(null, "paramName")]
         [InlineData(TestAssemblyName, null)]
         [InlineData(TestAssemblyName, "paramName")]
-        public void NI1004_StringLiteralInMethodInvocation_BaseTypeExemptFromFile_AttributesMatch_NoDiagnostic(string assemblyName, string parameterName)
+        public void NI1004_StringLiteralInMethodInvocation_BaseTypeExemptFromFile_AttributesMatch_NoDiagnostic(string? assemblyName, string? parameterName)
         {
             var test = new AutoTestFile($@"
 using System;
@@ -1327,7 +1327,7 @@ class Program
     }}
 }}");
 
-            var attributes = GetNonNullAttributesString(new Dictionary<string, string>
+            var attributes = GetNonNullAttributesString(new Dictionary<string, string?>
             {
                 ["Assembly"] = assemblyName,
                 ["Parameter"] = parameterName,
@@ -1340,7 +1340,7 @@ class Program
         [InlineData(null, "wrong")]
         [InlineData("Different", null)]
         [InlineData("Different", "wrong")]
-        public void NI1004_StringLiteralInMethodInvocation_BaseTypeExemptFromFile_AttributesMismatch_Diagnostic(string assemblyName, string parameterName)
+        public void NI1004_StringLiteralInMethodInvocation_BaseTypeExemptFromFile_AttributesMismatch_Diagnostic(string? assemblyName, string? parameterName)
         {
             var test = new AutoTestFile(
                 $@"
@@ -1355,7 +1355,7 @@ class Program
 }}",
                 GetNI1004LiteralRule(ExampleLiteral));
 
-            var attributes = GetNonNullAttributesString(new Dictionary<string, string>
+            var attributes = GetNonNullAttributesString(new Dictionary<string, string?>
             {
                 ["Assembly"] = assemblyName,
                 ["Parameter"] = parameterName,
@@ -2403,7 +2403,7 @@ class Foo
             return new TestAdditionalDocument((fileInfo ?? defaultFileInfo).Name, documentContents);
         }
 
-        private string GetNonNullAttributesString(Dictionary<string, string> attributeNameToValue)
+        private string GetNonNullAttributesString(Dictionary<string, string?> attributeNameToValue)
         {
             return string.Join(" ", attributeNameToValue.Where(x => !string.IsNullOrEmpty(x.Value)).Select(x => $@"{x.Key}=""{x.Value}"""));
         }

--- a/tests/NationalInstruments.Analyzers.Utilities.UnitTests/AdditionalFileServiceTests.cs
+++ b/tests/NationalInstruments.Analyzers.Utilities.UnitTests/AdditionalFileServiceTests.cs
@@ -74,7 +74,7 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
 
             additionalFileService.ParseXmlFile(additionalFile);
 
-            Assert.Equal(1, additionalFileService.ParsingDiagnostics.Count);
+            Assert.Single(additionalFileService.ParsingDiagnostics);
             Assert.Equal(FileParseRuleId, additionalFileService.ParsingDiagnostics[0].Id);
             Assert.Equal(ExpectedExceptionMessage, additionalFileService.ParsingDiagnostics[0].GetMessage());
         }

--- a/tests/NationalInstruments.Analyzers.Utilities.UnitTests/ExemptionCollectionTests.cs
+++ b/tests/NationalInstruments.Analyzers.Utilities.UnitTests/ExemptionCollectionTests.cs
@@ -50,7 +50,9 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
             };
 
             Assert.Single(exemptions);
-            Assert.Single(exemptions["foo"]);
+            var foo = exemptions["foo"];
+            Assert.NotNull(foo);
+            Assert.Single(foo);
         }
 
         [Fact]
@@ -63,13 +65,14 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
             };
 
             var attributes = exemptions["foo"];
+            Assert.NotNull(attributes);
 
             Assert.Single(exemptions);
             Assert.Single(attributes);
 
-            Assert.DoesNotContain("Assembly", attributes?.Names);
-            Assert.Contains("Parameter", attributes?.Names);
-            Assert.Single(attributes?["Parameter"]);
+            Assert.DoesNotContain("Assembly", attributes.Names);
+            Assert.Contains("Parameter", attributes.Names);
+            Assert.Single(attributes["Parameter"]);
         }
 
         [Fact]
@@ -82,13 +85,14 @@ namespace NationalInstruments.Analyzers.Utilities.UnitTests
             };
 
             var attributes = exemptions["foo"];
+            Assert.NotNull(attributes);
 
             Assert.Single(exemptions);
             Assert.Single(attributes);
 
-            Assert.Contains("Assembly", attributes?.Names);
+            Assert.Contains("Assembly", attributes.Names);
 
-            var attributeValues = attributes?["Assembly"];
+            var attributeValues = attributes["Assembly"];
             Assert.Contains("A", attributeValues);
             Assert.Contains("B", attributeValues);
         }

--- a/tests/NationalInstruments.Analyzers.Utilities.UnitTests/NationalInstruments.Analyzers.Utilities.UnitTests.csproj
+++ b/tests/NationalInstruments.Analyzers.Utilities.UnitTests/NationalInstruments.Analyzers.Utilities.UnitTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(NIAnalyzersTargetFramework)</TargetFramework>
     <AssemblyName>NationalInstruments.Analyzers.Utilities.UnitTests</AssemblyName>
     <RootNamespace>NationalInstruments.Analyzers.Utilities.UnitTests</RootNamespace>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Justification
The CSharp analyzer has quite a few updates since 4.2.0, including new APIs and new analyzer rules for writing analyzers.

To help keep the analyzer code current, we should upgrade the analyzer versions and fix any new warnings in our analyzers.

# Implementation
- Update the nuget packages related to implementing analyzers to latest stable—the code analyzer nugets, such as style cop, are *not* updated.
- Fix any new warnings in our custom analyzer code.

# Testing
Code builds and all tests continue to pass.