### PR TITLE
Update Threading and StyleCop analyzers to latest

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,9 +8,9 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.9.2" />
     <PackageVersion Include="Microsoft.VisualStudio.TestPlatform" Version="14.0.0" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.10.48" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="16.0.102" />
-    <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />
+    <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
     <PackageVersion Include="xunit.assert" Version="2.7.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageVersion Include="xunit" Version="2.7.0" />

--- a/build/NI.CSharp.Analyzers.nuspec
+++ b/build/NI.CSharp.Analyzers.nuspec
@@ -6,7 +6,7 @@
     <!--TODO: author and owner may have to change if we go to nuget.org -->
     <authors>NI</authors>
     <owners>NI</owners>
-    <copyright>Copyright 2023 National Instruments Corporation</copyright>
+    <copyright>Copyright 2024 National Instruments Corporation</copyright>
     <description>NI's code analyzers and rulesets for C# projects.</description>
     <summary>NI's code analyzers and rulesets for C# projects.</summary>
     <icon>images\icon.png</icon>
@@ -24,8 +24,8 @@
         <dependency id="Microsoft.CodeAnalysis.NetAnalyzers" version="8.0.0" />
         <dependency id="Microsoft.CodeAnalysis.CSharp" version="4.2.0" />
         <dependency id="Microsoft.CodeAnalysis.Analyzers" version="3.3.3" />
-        <dependency id="Microsoft.VisualStudio.Threading.Analyzers" version="17.2.32" />
-        <dependency id="StyleCop.Analyzers" version="1.2.0-beta.435" />
+        <dependency id="Microsoft.VisualStudio.Threading.Analyzers" version="17.10.48" />
+        <dependency id="StyleCop.Analyzers" version="1.2.0-beta.566" />
         <dependency id="Roslynator.Analyzers" version="4.1.1" />
       </group>
     </dependencies>

--- a/build/NI.CSharp.Analyzers.nuspec
+++ b/build/NI.CSharp.Analyzers.nuspec
@@ -25,7 +25,7 @@
         <dependency id="Microsoft.CodeAnalysis.CSharp" version="4.2.0" />
         <dependency id="Microsoft.CodeAnalysis.Analyzers" version="3.3.3" />
         <dependency id="Microsoft.VisualStudio.Threading.Analyzers" version="17.10.48" />
-        <dependency id="StyleCop.Analyzers" version="1.2.0-beta.566" />
+        <dependency id="StyleCop.Analyzers" version="1.2.0-beta.556" />
         <dependency id="Roslynator.Analyzers" version="4.1.1" />
       </group>
     </dependencies>


### PR DESCRIPTION
# Justification
There are new releases of `Microsoft.VisualStudio.Threading.Analyzers` and `StyleCop.Analyzers.Unstable` and we should keep current—for both the analyzer code and the analyzer dependencies.

In particular, the latest release of `StyleCop.Analyzers.Unstable` addresses[ SA1010 false positive](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3687) when using the new [C# 12 collection expression syntax](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/collection-expressions).
# Implementation
- Update the analyzers used by the analyzer build to latest.
- Update the analyzers in the nuspec to latest.

# Testing
Analyzer builds without any warnings.