### PR TITLE
Mark the NI C# Analyzers package as a development dependency

### DIFF
--- a/build/NI.CSharp.Analyzers.nuspec
+++ b/build/NI.CSharp.Analyzers.nuspec
@@ -9,6 +9,7 @@
     <copyright>Copyright 2024 National Instruments Corporation</copyright>
     <description>NI's code analyzers and rulesets for C# projects.</description>
     <summary>NI's code analyzers and rulesets for C# projects.</summary>
+    <developmentDependency>true</developmentDependency>
     <icon>images\icon.png</icon>
     <repository type="git" url="https://github.com/ni/csharp-styleguide" />
     <projectUrl>https://github.com/ni/csharp-styleguide</projectUrl>


### PR DESCRIPTION
# Justification
This NuGet package only provides analyzers, and so should be marked as a development dependency.  This enables tooling to automatically exclude compile time assets, as well as prevent this package from being brought along as a dependency of other packages.  See [here](https://learn.microsoft.com/en-us/nuget/reference/nuspec#developmentdependency).

When marked as a development dependency, NuGet.org updates its PackageReference suggestion to include PrivateAssets and IncludeAssets tags - like the following:

```xml
<PackageReference Include="xunit.analyzers" Version="1.15.0">
  <PrivateAssets>all</PrivateAssets>
  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
</PackageReference>
```

# Implementation
Mark `developmentDependency = true` in the .nuspec file.

# Testing
Built the nuget package locally, and verified it is marked as a development dependency:
![image](https://github.com/user-attachments/assets/0fcb5cf8-a8c0-4544-90e1-8535f3cfef8c)
