### PR TITLE
Update net analyzers to 9.0

### DIFF
--- a/build/NI.CSharp.Analyzers.nuspec
+++ b/build/NI.CSharp.Analyzers.nuspec
@@ -22,7 +22,7 @@
           major version, make sure to update AnalysisLevel in NI.CSharp.Analysers.props
           too, otherwise new rules will not be properly enabled.
         -->
-        <dependency id="Microsoft.CodeAnalysis.NetAnalyzers" version="8.0.0" />
+        <dependency id="Microsoft.CodeAnalysis.NetAnalyzers" version="9.0.0" />
         <dependency id="Microsoft.CodeAnalysis.CSharp" version="4.2.0" />
         <dependency id="Microsoft.CodeAnalysis.Analyzers" version="3.3.3" />
         <dependency id="Microsoft.VisualStudio.Threading.Analyzers" version="17.10.48" />

--- a/src/AnalyzerConfiguration/NI.CSharp.Analyzers.props
+++ b/src/AnalyzerConfiguration/NI.CSharp.Analyzers.props
@@ -31,12 +31,12 @@
     <AnalysisMode Condition="'$(AnalysisMode)' == ''">NI</AnalysisMode>
 
     <!--
-      If AnalysisLevel is not set, the .NET SDK will default to the version of the SDK.  If the SDK is less than .NET 8,
-      then despite having a .NET 8 analyzer nuget referenced, we will use the lower SDK version as the analysis level.
+      If AnalysisLevel is not set, the .NET SDK will default to the version of the SDK.  If the SDK is less than .NET 9,
+      then despite having a .NET 9 analyzer nuget referenced, we will use the lower SDK version as the analysis level.
 
-      Thus we manually set the default analysis level to 8.0 to make sure .NET 8 warnings are still checked.
+      Thus we manually set the default analysis level to 9.0 to make sure .NET 9 warnings are still checked.
     -->
-    <AnalysisLevel Condition="'$(AnalysisLevel)' == ''">8.0</AnalysisLevel>
+    <AnalysisLevel Condition="'$(AnalysisLevel)' == ''">9.0</AnalysisLevel>
   </PropertyGroup>
 
   <!-- 


### PR DESCRIPTION
# Justification
With the release of .NET 9 there are new analyzers we can use.

# Implementation
- Update `Microsoft.CodeAnalysis.NetAnalyzers` to `9.0.0`.
- Update the default `AnalysisLevel` to `9.0` so that consumers using older .NET SDK will still get to use the new .NET 9 analyzers.

# Testing
Built nupkg locally and confirmed new warnings are emitted in ASW when the analyzer package is updated.