### PR TITLE
Update to .NET 8

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <NILibraryTargetFramework>net6.0</NILibraryTargetFramework>
-        <NIExecutableTargetFramework>net6.0</NIExecutableTargetFramework>
+        <NILibraryTargetFramework>net8.0</NILibraryTargetFramework>
+        <NIExecutableTargetFramework>net8.0</NIExecutableTargetFramework>
         <NIAnalyzersTargetFramework>netstandard2.0</NIAnalyzersTargetFramework>
 
         <Nullable>enable</Nullable>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.400",
+    "version": "8.0.410",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.400",
+    "version": "8.0.400",
     "rollForward": "latestFeature"
   }
 }

--- a/nuget.config
+++ b/nuget.config
@@ -5,6 +5,5 @@
     <add key="automatic" value="True" />
   </packageRestore>
   <packageSources>
-    <add key="NuGet" value="https://www.nuget.org/api/v2/" />
   </packageSources>
 </configuration>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -10,7 +10,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <NILibraryTargetFramework>net6.0</NILibraryTargetFramework>
+    <NILibraryTargetFramework>net8.0</NILibraryTargetFramework>
     <NIAnalyzersTargetFramework>net48</NIAnalyzersTargetFramework>
   </PropertyGroup>
 


### PR DESCRIPTION
# Justification
.NET 6 has reached its end of life, and the `actions/setup-dotnet@v1` step used in the csharp-styleguide workflow no longer installs it. We need to update to .NET 8 to prevent build errors.

# Implementation
- Updated global.json to use .NET 8 (same as the one in ASW)
- Removed the NuGet package source in nuget.config to void NU1507 warnings
- Updated the NIExecutableTargetFramework and NILibraryTargetFramework properties to net8.0.

# Testing
builds