### PR TITLE
Fix NuGet publish path after .NET 8 upgrade

### DIFF
--- a/.github/workflows/automatic-publish.yml
+++ b/.github/workflows/automatic-publish.yml
@@ -59,6 +59,6 @@ jobs:
         run: dotnet pack .\src\NationalInstruments.Analyzers\NationalInstruments.Analyzers.csproj -p:NuspecFile=../../build/NI.CSharp.Analyzers.nuspec --no-build -p:NuspecProperties="Version=${{ steps.gitversion.outputs.nuGetVersionV2 }}"
 
       - name: Publish Nuget Package
-        run: dotnet nuget push .\.binaries\NationalInstruments.Analyzers\*.nupkg --skip-duplicate --no-symbols --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push .\.binaries\Release\NationalInstruments.Analyzers\*.nupkg --skip-duplicate --no-symbols --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
 
 


### PR DESCRIPTION
# Justification
The NuGet publishing pipeline failed because the built NuGet package could not be located. This issue occurred after upgrading to .NET 8 (see #102), as the build configuration is now included in the NuGet path.

<img width="1932" height="256" alt="image" src="https://github.com/user-attachments/assets/993fbff8-c8fb-4b3d-9258-83b12e49cd35" />

# Implementation
Update the path to the nupkg to include `Release` 

# Testing
Verified the new path exists.